### PR TITLE
Use gorm.DeletedAt from DeletedAt base model attribute

### DIFF
--- a/rest/models/base.go
+++ b/rest/models/base.go
@@ -2,12 +2,14 @@ package models
 
 import (
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // Generic Struct used throughout models in this service.
 type BaseModel struct {
-	Id        uint 			`gorm:"primarykey" json:"id,omitempty"`
-	CreatedAt time.Time `json:"createdAt,omitempty"`
-	UpdatedAt time.Time `json:"updatedAt,omitempty"`
-	DeletedAt time.Time `json:"deletedAt,omitempty"`
+	Id        uint           `gorm:"primarykey" json:"id,omitempty"`
+	CreatedAt time.Time      `json:"createdAt,omitempty"`
+	UpdatedAt time.Time      `json:"updatedAt,omitempty"`
+	DeletedAt gorm.DeletedAt `json:"deletedAt,omitempty"`
 }


### PR DESCRIPTION
We do need the special type to avoid having default values in our responses and correct DB queries. We have figured out the OpenAPI issue so we can now safely use it.