### PR TITLE
[RHCLOUD-23187] Ignore kubelinter minimum replica alert 

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -8,6 +8,8 @@ objects:
     kind: ClowdApp
     metadata: 
       name: chrome-service
+      annotations:
+        ${LINT_ANNOTATION}: "minimum three replicas not required"
     spec:
       envName: ${ENV_NAME}
       database:
@@ -71,3 +73,5 @@ parameters:
 - description: ClowdEnv Name
   name: ENV_NAME
   required: true
+- name: LINT_ANNOTATION
+  value: 'ignore-check.kube-linter.io/minimum-three-replicas'


### PR DESCRIPTION
Resolves the alert included in the ticket. We don't have enough traffic to warrant two additional replicas on stage. When we get to prod, three replicas will be useful and this will be irrelevant. 