### PR TITLE
Update API path to match gateway

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	router.Get("/health", HealthProbe)
 
-	router.Route("/api/chrome/v1/", func(subrouter chi.Router) {
+	router.Route("/api/chrome-service/v1/", func(subrouter chi.Router) {
 		subrouter.Use(m.ParseHeaders)
 		subrouter.Use(m.InjectUser)
 		subrouter.Get("/hello-world", HelloWorld)


### PR DESCRIPTION
Service is now listed as `chrome-service` in 3scale, and this mismatch is causing 404s.