### PR TITLE
Update last visited if account gets in bad state

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ Go 1.18
 
 ## Local Testing
 
-1. There are environment variables that are necessary for the application to start. Please copy the contents within `env.example` and move them over to a new `.env` file at the root of your local app directory. There, set the values of the variables accordingly for your local db configuration. 
+1. There are environment variables that are necessary for the application to start. Please copy the contents within `env.example` and move them over to a new `.env` file at the root of your local app directory. There, set the values of the variables accordingly for your local db configuration. This repo also supports `docker-compose up` for its postgres server. An example `.env` for this would look like:
+```
+PGSQL_USER=chrome
+PGSQL_PASSWORD=chrome
+PGSQL_HOSTNAME=0.0.0.0
+PGSQL_PORT=5432
+PGSQL_DATABASE=postgres
+```
 2. Run the server by using `go run .` or `go run main.go`
 3. To test the service, at the moment, you are able to hit the followind endpoint:
 ```

--- a/rest/service/lastVisistedService.go
+++ b/rest/service/lastVisistedService.go
@@ -39,7 +39,7 @@ func AddNewPage(pages []models.LastVisitedPage, currentPage models.LastVisitedPa
 		}
 	} else if len(pages) > util.LAST_VISITED_MAX {
 		// if account gets in bad state, remove all until max allowed remain
-		for i := util.LAST_VISITED_MAX; i < len(pages); i++ {
+		for i := util.LAST_VISITED_MAX - 1; i < len(pages); i++ {
 			err = database.DB.Unscoped().Delete(pages[i]).Error
 			if err != nil {
 				return err

--- a/rest/service/lastVisistedService.go
+++ b/rest/service/lastVisistedService.go
@@ -37,6 +37,14 @@ func AddNewPage(pages []models.LastVisitedPage, currentPage models.LastVisitedPa
 		if err != nil {
 			return err
 		}
+	} else if len(pages) > util.LAST_VISITED_MAX {
+		// if account gets in bad state, remove all until max allowed remain
+		for i := util.LAST_VISITED_MAX; i < len(pages); i++ {
+			err = database.DB.Unscoped().Delete(pages[i]).Error
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return database.DB.Create(&currentPage).Error


### PR DESCRIPTION
For [RHCLOUD-23907](https://issues.redhat.com/browse/RHCLOUD-23907). Tested locally with docker-compose for postgres and creating a user with > 10 last visited pages. A `POST` to `/v1/last-visited` with a unique route correctly reduces the number of items in the list to 10. 