### PR TITLE
Do not send nil as visited bundles.

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -6,15 +6,38 @@ import (
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 )
 
 func main() {
 	godotenv.Load()
 	config.Init()
 	database.Init()
-	err := database.DB.AutoMigrate(&models.FavoritePage{}, &models.LastVisitedPage{}, &models.SelfReport{}, &models.UserIdentity{}, &models.ProductOfInterest{})
+
+	var bundleRes *gorm.DB
+
+	// Wrap DB migration into a single transaction
+	err := database.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.AutoMigrate(&models.FavoritePage{}, &models.LastVisitedPage{}, &models.SelfReport{}, &models.UserIdentity{}, &models.ProductOfInterest{})
+		if err != nil {
+			return err
+		}
+		// Migrate all nil visited_bundles to empty object
+		bundleRes = database.DB.Model(&models.UserIdentity{}).Where("visited_bundles IS NULL").Update("visited_bundles", []byte(`{}`))
+		if bundleRes.Error != nil {
+			return bundleRes.Error
+		}
+
+		return nil
+	})
+
 	if err != nil {
+		logrus.Error("Unable to migrate database!")
 		panic(err)
+	}
+
+	if bundleRes.RowsAffected > 0 {
+		logrus.Infof("Migrated %d user identity bundles rows", bundleRes.RowsAffected)
 	}
 	logrus.Info("Migration complete")
 }

--- a/rest/models/UserIdentity.go
+++ b/rest/models/UserIdentity.go
@@ -15,5 +15,5 @@ type UserIdentity struct {
 	LastVisitedPages []LastVisitedPage `json:"lastVisitedPages"`
 	FavoritePages    []FavoritePage    `json:"favoritePages"`
 	SelfReport       SelfReport        `json:"selfReport"`
-	VisitedBundles   datatypes.JSON    `json:"visitedBundles" gorm:"type: JSONB"`
+	VisitedBundles   datatypes.JSON    `json:"visitedBundles,omitempty" gorm:"type: JSONB"`
 }

--- a/rest/service/identity.go
+++ b/rest/service/identity.go
@@ -10,6 +10,10 @@ import (
 
 func parseUserBundles(user models.UserIdentity) (map[string]bool, error) {
 	bundles := make(map[string]bool)
+	// make sure not to potentially marshal nil to map
+	if user.VisitedBundles == nil {
+		return bundles, nil
+	}
 	err := json.Unmarshal(user.VisitedBundles, &bundles)
 	return bundles, err
 }


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-24446

### Changes
- Do not return visitedBundles attribute if value is equal to `null`
- Add migration script to fill `visited_bundles` to `{}` if record value is equal to `NULL`
- Run DB migrations in a single transaction 