### PR TITLE
feat: remove openshift nav items

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -169,18 +169,6 @@
             ]
         },
         {
-            "title": "Support Cases",
-            "href": "https://access.redhat.com/support/cases",
-            "filterable": false,
-            "isExternal": true
-        },
-        {
-            "title": "Cluster Manager Feedback",
-            "href": "mailto:ocm-feedback@redhat.com",
-            "filterable": false,
-            "isExternal": true
-        },
-        {
             "title": "Red Hat Marketplace",
             "href": "https://marketplace.redhat.com",
             "filterable": false,

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -209,18 +209,6 @@
             ]
         },
         {
-            "id": "supportCases",
-            "title": "Support Cases",
-            "href": "https://access.redhat.com/support/cases",
-            "isExternal": true
-        },
-        {
-            "id": "clusterManagerFeedback",
-            "title": "Cluster Manager Feedback",
-            "href": "mailto:ocm-feedback@redhat.com",
-            "isExternal": true
-        },
-        {
             "id": "redhatMarketplace",
             "title": "Red Hat Marketplace",
             "href": "https://marketplace.redhat.com",

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -169,18 +169,6 @@
             ]
         },
         {
-            "title": "Support Cases",
-            "href": "https://access.redhat.com/support/cases",
-            "filterable": false,
-            "isExternal": true
-        },
-        {
-            "title": "Cluster Manager Feedback",
-            "href": "mailto:ocm-feedback@redhat.com",
-            "filterable": false,
-            "isExternal": true
-        },
-        {
             "title": "Red Hat Marketplace",
             "href": "https://marketplace.redhat.com",
             "filterable": false,

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -173,16 +173,6 @@
             ]
         },
         {
-            "title": "Support Cases",
-            "href": "https://access.redhat.com/support/cases",
-            "isExternal": true
-        },
-        {
-            "title": "Cluster Manager Feedback",
-            "href": "mailto:ocm-feedback@redhat.com",
-            "isExternal": true
-        },
-        {
             "title": "Red Hat Marketplace",
             "href": "https://marketplace.redhat.com",
             "isExternal": true


### PR DESCRIPTION
For [RHCLOUD-24988](https://issues.redhat.com/browse/RHCLOUD-24988). @Hyperkid123 I'm still looking through the CSConfig -> chrome-service migration, but I'm assuming this is all that's needed to remove these two nav items.