### PR TITLE
Github Action workflow to validate fed-modules.json

### DIFF
--- a/.github/scripts/validate-fed-modules.sh
+++ b/.github/scripts/validate-fed-modules.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euo pipefail
+
+
+# Find all files named "fed-modules.json" in the "static" directory
+# and store their paths in an array named "files".
+files=($(find static -name "fed-modules.json"))
+
+valid=true
+
+
+for file in "${files[@]}"
+do
+
+  # Read the contents of the file and pass them to the jq command to extract all keys that are not camel-cased.
+  invalid_keys=$(cat $file | jq 'keys[] | select(test("^[a-z]+([A-Z][a-z]*)*$") | not)')
+  echo ""
+
+  if [ -z "$invalid_keys" ]; then
+      echo "${file} is valid."
+  else
+      echo "Error: ${file} is invalid. Below keys must be camel-cased."
+      echo "${invalid_keys}"      
+      valid=false
+  fi
+
+done
+
+
+# If any file was found to have invalid keys, exit the script with an error code.
+if ! "$valid"; then
+  exit 1
+fi

--- a/.github/workflows/validate-fed-modules.yaml
+++ b/.github/workflows/validate-fed-modules.yaml
@@ -1,0 +1,24 @@
+name: Validate fed-modules.json
+on:
+  pull_request:
+    branches: [main]
+    # Run only when fed-modules.json is changed in any subdirectory of the static folder.
+    paths:
+      - 'static/**/fed-modules.json'
+
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  validate:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code Ref '${{ github.ref }}'
+        uses: actions/checkout@v3
+
+      - name: Validate fed-modules.json
+        run: ./.github/scripts/validate-fed-modules.sh


### PR DESCRIPTION
In the recent attempt to add a new application, we encountered the issue of not using camel casing once again for the app-id. This has happened multiple times before and we only realize the mistake after spending a considerable amount of time on debugging.

[https://github.com/RedHatInsights/chrome-service-backend/pull/45](https://github.com/RedHatInsights/chrome-service-backend/pull/45 )

To address this, I am proposing the addition of a new Github Action workflow that will be triggered only when there is a change in fed-modules.json in any subdirectory of the static folder. The workflow will perform a validation check to ensure that the app-id specified in the fed-modules.json files is using camel case.This will ensure uniformity and save people from spending unnecessary time debugging the issue.