### PR TITLE
Automation Hub nav: replace "Repo Management" with "Repositories" and "Remotes"

### DIFF
--- a/static/beta/prod/navigation/ansible-navigation.json
+++ b/static/beta/prod/navigation/ansible-navigation.json
@@ -29,10 +29,17 @@
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "id": "repoManagement",
+                    "id": "repositories",
                     "appId": "automationHub",
-                    "title": "Repo Management",
-                    "href": "/ansible/automation-hub/repositories",
+                    "title": "Repositories",
+                    "href": "/ansible/automation-hub/ansible/repositories",
+                    "product": "Ansible Automation Hub"
+                },
+                {
+                    "id": "remotes",
+                    "appId": "automationHub",
+                    "title": "Remotes",
+                    "href": "/ansible/automation-hub/ansible/remotes",
                     "product": "Ansible Automation Hub"
                 },
                 {

--- a/static/beta/stage/navigation/ansible-navigation.json
+++ b/static/beta/stage/navigation/ansible-navigation.json
@@ -35,10 +35,17 @@
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "id": "repoManagement",
+                    "id": "repositories",
                     "appId": "automationHub",
-                    "title": "Repo Management",
-                    "href": "/ansible/automation-hub/repositories",
+                    "title": "Repositories",
+                    "href": "/ansible/automation-hub/ansible/repositories",
+                    "product": "Ansible Automation Hub"
+                },
+                {
+                    "id": "remotes",
+                    "appId": "automationHub",
+                    "title": "Remotes",
+                    "href": "/ansible/automation-hub/ansible/remotes",
                     "product": "Ansible Automation Hub"
                 },
                 {

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -29,10 +29,17 @@
                     "product": "Ansible Automation Hub"
                 },
                 {
+                    "id": "repositories",
                     "appId": "automationHub",
-                    "id": "repoManagement",
-                    "title": "Repo Management",
-                    "href": "/ansible/automation-hub/repositories",
+                    "title": "Repositories",
+                    "href": "/ansible/automation-hub/ansible/repositories",
+                    "product": "Ansible Automation Hub"
+                },
+                {
+                    "id": "remotes",
+                    "appId": "automationHub",
+                    "title": "Remotes",
+                    "href": "/ansible/automation-hub/ansible/remotes",
                     "product": "Ansible Automation Hub"
                 },
                 {

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -29,10 +29,17 @@
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "id": "repoManagement",
+                    "id": "repositories",
                     "appId": "automationHub",
-                    "title": "Repo Management",
-                    "href": "/ansible/automation-hub/repositories",
+                    "title": "Repositories",
+                    "href": "/ansible/automation-hub/ansible/repositories",
+                    "product": "Ansible Automation Hub"
+                },
+                {
+                    "id": "remotes",
+                    "appId": "automationHub",
+                    "title": "Remotes",
+                    "href": "/ansible/automation-hub/ansible/remotes",
                     "product": "Ansible Automation Hub"
                 },
                 {


### PR DESCRIPTION
Updates nav entries for Automation Hub:

```diff
-/ansible/automation-hub/repositories	Repo Management
+/ansible/automation-hub/ansible/repositories	Repositories
+/ansible/automation-hub/ansible/remotes	Remotes
```

we should ideally wait and merge this on Tue 5/2 to sync with hub deploy.