### PR TITLE
[stage-stable] Omit permissions check for the HCS "Overview" link

### DIFF
--- a/static/stable/stage/navigation/business-services-navigation.json
+++ b/static/stable/stage/navigation/business-services-navigation.json
@@ -13,16 +13,7 @@
             "appId": "hybridCommittedSpend",
             "title": "Overview",
             "href": "/business-services/hybrid-committed-spend",
-            "description": "Compare the difference between the commitment and actual Red Hat spending.",
-            "permissions": [
-              {
-                "method": "apiRequest",
-                "args": [{
-                  "url": "https://billing.qa.api.redhat.com/v1/authorization/hcsEnrollment",
-                  "accessor": "hcsDeal"
-                }]
-              }
-            ]
+            "description": "Compare the difference between the commitment and actual Red Hat spending."
           },
           {
             "id": "details",


### PR DESCRIPTION
Omit permissions check for the "Overview" link. 

"The intent was to hide HCS completely from non-HCS users" -- Greg Bowman
