### PR TITLE
[prod-beta] Add missing fed-modules entry for HCS

### DIFF
--- a/static/beta/prod/modules/fed-modules.json
+++ b/static/beta/prod/modules/fed-modules.json
@@ -751,6 +751,20 @@
             }
         ]
     },
+    "hybridCommittedSpend": {
+        "manifestLocation": "/apps/hybrid-committed-spend/fed-mods.json",
+        "modules": [
+            {
+                "id": "hybrid-committed-spend",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/business-services/hybrid-committed-spend"
+                    }
+                ]
+            }
+        ]
+    },
     "connect": {
         "manifestLocation": "/apps/connect/fed-mods.json",
         "modules": [


### PR DESCRIPTION
1. Add missing fed-modules entry
2. Omit permissions check for the "Overview" link.

"The intent was to hide the HCS UI completely from non-HCS users" -- Greg Bowman
