### PR TITLE
Do not use corp proxy for prod seach index uploads.

### DIFF
--- a/cmd/search/publishSearchIndex.go
+++ b/cmd/search/publishSearchIndex.go
@@ -384,14 +384,8 @@ func uploadIndex(token string, index []ModuleIndexEntry, host string) error {
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyURL(&url.URL{
-				Scheme: "http",
-				Host:   "squid.corp.redhat.com:3128",
-			}),
-		},
-	}
+	client := &http.Client{}
+
 	res, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
We need to offload the uploading of the search index to Jenkins. For now, lets at least upload the prod search index.