### PR TITLE
Automation Hub - revert prod to "Repo Management"

### DIFF
--- a/static/beta/prod/navigation/ansible-navigation.json
+++ b/static/beta/prod/navigation/ansible-navigation.json
@@ -29,17 +29,10 @@
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "id": "repositories",
+                    "id": "repoManagement",
                     "appId": "automationHub",
-                    "title": "Repositories",
-                    "href": "/ansible/automation-hub/ansible/repositories",
-                    "product": "Ansible Automation Hub"
-                },
-                {
-                    "id": "remotes",
-                    "appId": "automationHub",
-                    "title": "Remotes",
-                    "href": "/ansible/automation-hub/ansible/remotes",
+                    "title": "Repo Management",
+                    "href": "/ansible/automation-hub/repositories",
                     "product": "Ansible Automation Hub"
                 },
                 {

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -29,17 +29,10 @@
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "id": "repositories",
                     "appId": "automationHub",
-                    "title": "Repositories",
-                    "href": "/ansible/automation-hub/ansible/repositories",
-                    "product": "Ansible Automation Hub"
-                },
-                {
-                    "id": "remotes",
-                    "appId": "automationHub",
-                    "title": "Remotes",
-                    "href": "/ansible/automation-hub/ansible/remotes",
+                    "id": "repoManagement",
+                    "title": "Repo Management",
+                    "href": "/ansible/automation-hub/repositories",
                     "product": "Ansible Automation Hub"
                 },
                 {


### PR DESCRIPTION
reverting half of #66,
Hub is deploying older changes than I thought,
so prod still needs the "Repo Management" menu item

(stage-beta already has the new route working, stage-stable gets updated after prod deploy, so this only revers prod-beta and prod-stable)

Cc @Hyperkid123 , sorry for the confusion