### PR TITLE
Update Unleash flag names

### DIFF
--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -184,7 +184,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.ibm", true]
+                                    "args": ["cost-management.ui.nav.ibm", true]
                                 }
                             ]
                         },
@@ -225,7 +225,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.settings", true]
+                                    "args": ["cost-management.ui.nav.settings", true]
                                 }
                             ]
                         }

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -178,7 +178,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.ibm", true]
+                                    "args": ["cost-management.ui.nav.ibm", true]
                                 }
                             ]
                         },


### PR DESCRIPTION
Cost Management uses user IDs with Unleash to develop and test in the stage env. However, the "featureFlag" method does not appear to support it. 

Seems the "featureFlag" method  must use a "standard strategy", which is "on/off for all users". Therefore, we're going to create unique feature flags for nav items.