### PR TITLE
fix: Change Observe - RHEL link to Advisor

### DIFF
--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -141,7 +141,7 @@
         "isGroup": true,
         "title": "RHEL",
         "links": [
-          "rhel.systems",
+          "rhel.recommendations",
           "rhel.images",
           "rhel.vulnerability",
           "rhel.compliance",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-4743.

Observe - RHEL bundle must contain "Recommendations" instead of "Systems".