### PR TITLE
[RHCLOUD-24573] Add learning resources nav items and config to stage stable

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -37,7 +37,7 @@
     },
     "learningResources": {
         "manifestLocation": "/apps/learningResources/fed-mods.json",
-        "defaultDocumentTitle": "Learning Resources | Settings",
+        "defaultDocumentTitle": "Learning Resources",
         "modules": [
             {
                 "id": "learningResources",

--- a/static/beta/stage/navigation/application-services-navigation.json
+++ b/static/beta/stage/navigation/application-services-navigation.json
@@ -11,7 +11,7 @@
     },
     {
       "id": "learningResources",
-      "appId": "applicationServices",
+      "appId": "learningResources",
       "title": "Learning Resources",
       "href": "/application-services/learning-resources"
     },

--- a/static/beta/stage/navigation/iam-navigation.json
+++ b/static/beta/stage/navigation/iam-navigation.json
@@ -66,7 +66,7 @@
       ]
     },
     {
-      "id": "documentation",
+      "id": "learningResources",
       "appId": "learningResources",
       "title": "Learning Resources",
       "href": "/iam/learning-resources"

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -11,6 +11,12 @@
       "product": "Red Hat Insights"
     },
     {
+      "id": "learningResources",
+      "appId": "learningResources",
+      "title": "Learning Resources",
+      "href": "/insights/learning-resources"
+    },
+    {
       "title": "Inventory",
       "expandable": true,
       "routes": [

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -887,50 +887,50 @@
           {
               "id": "learningResources",
               "module": "./RootApp",
-            "routes": [
-                {
-                    "pathname": "/application-services/learning-resources",
-                    "props": {
-                        "bundle": "application-services"
-                    }
-                },
-                {
-                    "pathname": "/openshift/learning-resources",
-                    "props": {
-                        "bundle": "openshift"
-                    }
-                },
-                {
-                    "pathname": "/ansible/learning-resources",
-                    "props": {
-                        "bundle": "ansible"
-                    }
-                },
-                {
-                    "pathname": "/insights/learning-resources",
-                    "props": {
-                        "bundle": "insights"
-                    }
-                },
-                {
-                    "pathname": "/edge/learning-resources",
-                    "props": {
-                        "bundle": "edge"
-                    }
-                },
-                {
-                    "pathname": "/settings/learning-resources",
-                    "props": {
-                        "bundle": "settings"
-                    }
-                },
-                {
-                    "pathname": "/iam/learning-resources",
-                    "props": {
-                        "bundle": "iam"
-                    }
-                }
-            ]
+              "routes": [
+                  {
+                      "pathname": "/application-services/learning-resources",
+                      "props": {
+                          "bundle": "application-services"
+                      }
+                  },
+                  {
+                      "pathname": "/openshift/learning-resources",
+                      "props": {
+                          "bundle": "openshift"
+                      }
+                  },
+                  {
+                      "pathname": "/ansible/learning-resources",
+                      "props": {
+                          "bundle": "ansible"
+                      }
+                  },
+                  {
+                      "pathname": "/insights/learning-resources",
+                      "props": {
+                          "bundle": "insights"
+                      }
+                  },
+                  {
+                      "pathname": "/edge/learning-resources",
+                      "props": {
+                          "bundle": "edge"
+                      }
+                  },
+                  {
+                      "pathname": "/settings/learning-resources",
+                      "props": {
+                          "bundle": "settings"
+                      }
+                  },
+                  {
+                      "pathname": "/iam/learning-resources",
+                      "props": {
+                          "bundle": "iam"
+                      }
+                  }
+              ]
           }
       ]
   }

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -887,11 +887,50 @@
           {
               "id": "learningResources",
               "module": "./RootApp",
-              "routes": [
-                  {
-                      "pathname": "/settings/learning-resources"
-                  }
-              ]
+            "routes": [
+                {
+                    "pathname": "/application-services/learning-resources",
+                    "props": {
+                        "bundle": "application-services"
+                    }
+                },
+                {
+                    "pathname": "/openshift/learning-resources",
+                    "props": {
+                        "bundle": "openshift"
+                    }
+                },
+                {
+                    "pathname": "/ansible/learning-resources",
+                    "props": {
+                        "bundle": "ansible"
+                    }
+                },
+                {
+                    "pathname": "/insights/learning-resources",
+                    "props": {
+                        "bundle": "insights"
+                    }
+                },
+                {
+                    "pathname": "/edge/learning-resources",
+                    "props": {
+                        "bundle": "edge"
+                    }
+                },
+                {
+                    "pathname": "/settings/learning-resources",
+                    "props": {
+                        "bundle": "settings"
+                    }
+                },
+                {
+                    "pathname": "/iam/learning-resources",
+                    "props": {
+                        "bundle": "iam"
+                    }
+                }
+            ]
           }
       ]
   }

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -10,6 +10,12 @@
             "href": "/ansible/ansible-dashboard"
         },
         {
+            "id": "learningResources",
+            "appId": "learningResources",
+            "title": "Learning Resources",
+            "href": "/ansible/learning-resources"
+        },
+        {
             "title": "Automation Hub",
             "expandable": true,
             "routes": [
@@ -115,7 +121,7 @@
             ]
         },
         {
-            "id":"ansibleExternalDocumentation",
+            "id": "ansibleExternalDocumentation",
             "title": "Documentation",
             "isExternal": true,
             "filterable": false,

--- a/static/stable/stage/navigation/application-services-navigation.json
+++ b/static/stable/stage/navigation/application-services-navigation.json
@@ -11,7 +11,7 @@
     },
     {
         "id": "learningResources",
-        "appId": "applicationServices",
+        "appId": "learningResources",
         "title": "Learning Resources",
         "href": "/application-services/learning-resources"
     },

--- a/static/stable/stage/navigation/edge-navigation.json
+++ b/static/stable/stage/navigation/edge-navigation.json
@@ -74,7 +74,7 @@
     }, {
       "id": "learningResources",
       "title": "Learning resources",
-      "appId": "edge",
+      "appId": "learningResources",
       "filterable": false,
       "href": "/edge/learning-resources",
       "permissions": [

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -52,6 +52,12 @@
       ]
     },
     {
+      "id": "learningResources",
+      "appId": "learningResources",
+      "title": "Learning Resources",
+      "href": "/iam/learning-resources"
+    },
+    {
       "id": "documentation",
       "title": "Documentation",
       "isExternal": true,

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -20,6 +20,12 @@
             "description": "Overview of your Openshift Environment."
         },
         {
+            "id": "learningResources",
+            "appId": "learningResources",
+            "title": "Learning Resources",
+            "href": "/openshift/learning-resources"
+        },
+        {
             "id": "releases",
             "appId": "openshift",
             "href": "/openshift/releases",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -11,6 +11,12 @@
         "product": "Red Hat Insights"
       },
       {
+        "id": "learningResources",
+        "appId": "learningResources",
+        "title": "Learning Resources",
+        "href": "/insights/learning-resources"
+      },
+      {
         "groupId": "business",
         "icon": "trend-up",
         "title": "Red Hat Insights",


### PR DESCRIPTION
* Adds nav items for each element and updates fed-modules to pass in the correct bundle for each nav item.

Note that some services DO NOT contain entries in the quickstarts repo and as such will only display an empty results page when their bundle is called. 

Apps with bundle data:
- insights
- settings
- iam

Apps without bundle data:
- edge
- openshift
- application-services
- ansible


![image](https://user-images.githubusercontent.com/12378666/236013596-3c574040-997f-4cdf-8ec6-b48d01b9cb48.png)
