### PR TITLE
Use parent nav titles for some services

### DIFF
--- a/static/beta/prod/navigation/business-services-navigation.json
+++ b/static/beta/prod/navigation/business-services-navigation.json
@@ -7,13 +7,14 @@
         "title": "Hybrid Committed Spend",
         "expandable": true,
         "filterable": false,
+        "id": "hybridCommittedSpend",
+        "description": "Compare the difference between the commitment and actual Red Hat spending.",
         "routes": [
           {
             "id": "overview",
             "appId": "hybridCommittedSpend",
             "title": "Overview",
             "href": "/business-services/hybrid-committed-spend",
-            "description": "Compare the difference between the commitment and actual Red Hat spending.",
             "permissions": [
               {
                 "method": "apiRequest",

--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -134,6 +134,8 @@
                     "title": "Cost Management",
                     "expandable": true,
                     "filterable": true,
+                    "description": "Understand and track costs for your OpenShift clusters and workloads.",
+                    "id": "costManagement",
                     "routes": [
                         {
                             "id": "costManagementOverview",
@@ -141,8 +143,7 @@
                             "title": "Overview",
                             "filterable": false,
                             "href": "/openshift/cost-management",
-                            "product": "Red Hat Cost Management",
-                            "description": "Understand and track costs for your OpenShift clusters and workloads."
+                            "product": "Red Hat Cost Management"
                         },
                         {
                             "id": "costManagementOptimizations",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -214,10 +214,10 @@
     "title": "Spend Management",
     "description": "Control costs and monitor committed spend.",
     "links": [
-      "openshift.costManagementOverview",
+      "openshift.costManagement",
       "rhel.subscriptionsInventory",
       "rhel.resourceOptimization",
-      "business-services.overview"
+      "business-services.hybridCommittedSpend"
     ]
   },
   {

--- a/static/beta/stage/navigation/business-services-navigation.json
+++ b/static/beta/stage/navigation/business-services-navigation.json
@@ -7,13 +7,14 @@
         "title": "Hybrid Committed Spend",
         "expandable": true,
         "filterable": false,
+        "id": "hybridCommittedSpend",
+        "description": "Compare the difference between the commitment and actual Red Hat spending.",
         "routes": [
           {
             "id": "overview",
             "appId": "hybridCommittedSpend",
             "title": "Overview",
-            "href": "/business-services/hybrid-committed-spend",
-            "description": "Compare the difference between the commitment and actual Red Hat spending."
+            "href": "/business-services/hybrid-committed-spend"
           },
           {
             "id": "details",

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -131,6 +131,8 @@
                 {
                     "title": "Cost Management",
                     "expandable": true,
+                    "description": "Understand and track costs for your OpenShift clusters and workloads.",
+                    "id": "costManagement",
                     "routes": [
                         {
                             "id": "costManagementOverview",
@@ -138,8 +140,7 @@
                             "title": "Overview",
                             "filterable": false,
                             "href": "/openshift/cost-management",
-                            "product": "Red Hat Cost Management",
-                            "description": "Understand and track costs for your OpenShift clusters and workloads."
+                            "product": "Red Hat Cost Management"
                         },
                         {
                             "id": "costManagementOptimizations",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -19,14 +19,15 @@
     {
       "title": "Inventory",
       "expandable": true,
+      "id": "inventory",
+      "description": "View details about your Red Hat Enterprise Linux systems.",
       "routes": [
         {
-          "id": "inventory",
+          "id": "systems",
           "appId": "inventory",
           "title": "Systems",
           "href": "/insights/inventory",
-          "product": "Red Hat Insights",
-          "description": "View details about your Red Hat Enterprise Linux systems."
+          "product": "Red Hat Insights"
         },
         {
           "id": "groups",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -213,10 +213,10 @@
     "title": "Spend Management",
     "description": "Control costs and monitor committed spend.",
     "links": [
-      "openshift.costManagementOverview",
+      "openshift.costManagement",
       "rhel.subscriptionsInventory",
       "rhel.resourceOptimization",
-      "business-services.overview"
+      "business-services.hybridCommittedSpend"
     ]
   },
   {

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -134,6 +134,8 @@
                     "title": "Cost Management",
                     "expandable": true,
                     "filterable": true,
+                    "description": "Understand and track costs for your OpenShift clusters and workloads.",
+                    "id": "costManagement",
                     "routes": [
                         {
                             "id": "costManagementOverview",
@@ -141,8 +143,7 @@
                             "title": "Overview",
                             "filterable": false,
                             "href": "/openshift/cost-management",
-                            "product": "Red Hat Cost Management",
-                            "description": "Understand and track costs for your OpenShift clusters and workloads."
+                            "product": "Red Hat Cost Management"
                         },
                         {
                             "id": "costManagementOptimizations",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -214,7 +214,7 @@
     "title": "Spend Management",
     "description": "Control costs and monitor committed spend.",
     "links": [
-      "openshift.costManagementOverview",
+      "openshift.costManagement",
       "rhel.subscriptionsInventory",
       "rhel.resourceOptimization"
     ]

--- a/static/stable/stage/navigation/business-services-navigation.json
+++ b/static/stable/stage/navigation/business-services-navigation.json
@@ -7,13 +7,14 @@
         "title": "Hybrid Committed Spend",
         "expandable": true,
         "filterable": false,
+        "id": "hybridCommittedSpend",
+        "description": "Compare the difference between the commitment and actual Red Hat spending.",
         "routes": [
           {
             "id": "overview",
             "appId": "hybridCommittedSpend",
             "title": "Overview",
             "href": "/business-services/hybrid-committed-spend",
-            "description": "Compare the difference between the commitment and actual Red Hat spending.",
             "permissions": [
               {
                 "method": "apiRequest",

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -137,6 +137,8 @@
                 {
                     "title": "Cost Management",
                     "expandable": true,
+                    "description": "Understand and track costs for your OpenShift clusters and workloads.",
+                    "id": "costManagement",
                     "routes": [
                         {
                             "id": "costManagementOverview",
@@ -144,8 +146,7 @@
                             "title": "Overview",
                             "filterable": false,
                             "href": "/openshift/cost-management",
-                            "product": "Red Hat Cost Management",
-                            "description": "Understand and track costs for your OpenShift clusters and workloads."
+                            "product": "Red Hat Cost Management"
                         },
                         {
                             "id": "costManagementOptimizations",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -213,10 +213,10 @@
     "title": "Spend Management",
     "description": "Control costs and monitor committed spend.",
     "links": [
-      "openshift.costManagementOverview",
+      "openshift.costManagement",
       "rhel.subscriptionsInventory",
       "rhel.resourceOptimization",
-      "business-services.overview"
+      "business-services.hybridCommittedSpend"
     ]
   },
   {


### PR DESCRIPTION
### Description

Some apps are using Overview in their navigation, this causes a bit of confusion when users are observing the services dropdown/All services page as there can be multiple Overview names. This PR fixes such issue by using paren't titles when applicable.

### JIRA

RHCLOUD-25743