### PR TITLE
RHIF-190: rename Overview to Dashboard, Inventory to Systems navs in stage env

### DIFF
--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -3,9 +3,9 @@
     "title": "Red Hat Insights",
     "navItems": [
       {
-        "id": "overview",
+        "id": "dashboard",
         "appId": "dashboard",
-        "title": "Overview",
+        "title": "Dashboard",
         "filterable": false,
         "href": "/insights/dashboard",
         "product": "Red Hat Insights"
@@ -24,7 +24,7 @@
           {
             "id": "inventory",
             "appId": "inventory",
-            "title": "Inventory",
+            "title": "Systems",
             "href": "/insights/inventory",
             "product": "Red Hat Insights",
             "description": "View details about your Red Hat Enterprise Linux systems."


### PR DESCRIPTION
This renames the following navigations in STAGE env to be aligned with the new Navigation changes [RHIF-190](https://issues.redhat.com/browse/RHIF-190).

Overview => Dashboard (navigation id is also changed to dashboard to make it same is the app URL)
Inventory => Systems

I will create the same PR for prod env once gets verified and ack.