### PR TITLE
RHIF-190: undo insights dashboard nav ID change

### DIFF
--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -5,7 +5,7 @@
     {
       "id": "overview",
       "appId": "dashboard",
-      "title": "Overview",
+      "title": "Dashboard",
       "filterable": false,
       "href": "/insights/dashboard",
       "product": "Red Hat Insights"


### PR DESCRIPTION
It seems changing the ID of the RHEL dashboard nav was not a good idea. After the PR got merged, this renaming did get reflected. This undoes that ID change.

Small question if you have time to answer, otherwise please ignore it: 
I am wondering what is difference between rhel-navigation.json and insights-navigation.json? It seems they are mapped to each other?