### PR TITLE
Put Learning Resources nav behind feature flag for insights bundle

### DIFF
--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -14,7 +14,13 @@
       "id": "learningResources",
       "appId": "learningResources",
       "title": "Learning Resources",
-      "href": "/insights/learning-resources"
+      "href": "/insights/learning-resources",
+      "permissions": [
+        {
+          "method": "featureFlag",
+          "args": ["rhel-insights.ui.nav.learning_resources", true]
+        }
+      ]
     },
     {
       "title": "Inventory",


### PR DESCRIPTION
This puts Learning resources nav behind a feature flag **rhel-insights.ui.nav.learning_resources** until the page is ready.