### PR TITLE
fix typo in minReplicas

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -19,7 +19,7 @@ objects:
         topicName: platform.chrome
       deployments:
       - name: api
-        minRecplicas: ${{MIN_REPLICAS}}
+        minReplicas: ${{MIN_REPLICAS}}
         webServices:
             public:
               apiPath: chrome-service


### PR DESCRIPTION
I don't know how we missed this, but replicas won't work unless this gets merged.