### PR TITLE
insights-bundle: remove learning resources and duplicate Product materials navs from prod env

### DIFF
--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -16,84 +16,54 @@
       "id": "inventory",
       "description": "View details about your Red Hat Enterprise Linux systems.",
       "routes": [
-          {
-            "id": "systems",
-            "appId": "inventory",
-            "title": "Systems",
-            "href": "/insights/inventory",
-            "product": "Red Hat Insights"
-          },
-          {
-            "id": "groups",
-            "appId": "inventory",
-            "title": "Groups",
-            "href": "/insights/inventory/groups",
-            "product": "Red Hat Insights",
-            "description": "Inventory groups",
-            "permissions": [
-              {
-                "method": "featureFlag",
-                "args": ["hbi.ui.inventory-groups", true]
-              }
-            ]
-          },
-          {
-            "id": "imageBuilder",
-            "appId": "imageBuilder",
-            "title": "Images",
-            "href": "/insights/image-builder",
-            "product": "Red Hat Insights",
-            "description": "Build and manage Red Hat Enterprise Linux images and environments."
-          },
-          {
-            "title": "System Configuration",
-            "expandable": true,
-            "routes": [
-              {
-                "id": "rhc",
-                "appId": "connector",
-                "title": "Remote Host Configuration (RHC)",
-                "href": "/settings/connector",
-                "product": "Red Hat Insights",
-                "description": "Configure your systems to execute Ansible Playbooks."
-              },
-              {
-                "id": "activationKeys",
-                "appId": "connector",
-                "title": "Activation Keys",
-                "href": "/settings/connector/activation-keys",
-                "product": "Red Hat Insights",
-                "description": "Create activation keys to register your systems and configure repositories without using a username and password."
-              }
+        {
+          "id": "systems",
+          "appId": "inventory",
+          "title": "Systems",
+          "href": "/insights/inventory",
+          "product": "Red Hat Insights"
+        },
+        {
+          "id": "groups",
+          "appId": "inventory",
+          "title": "Groups",
+          "href": "/insights/inventory/groups",
+          "product": "Red Hat Insights",
+          "description": "Inventory groups",
+          "permissions": [
+            {
+              "method": "featureFlag",
+              "args": ["hbi.ui.inventory-groups", true]
+            }
           ]
         },
         {
-          "id": "learningResources",
-          "appId": "learningResources",
-          "title": "Learning Resources",
-          "href": "/insights/learning-resources"
+          "id": "imageBuilder",
+          "appId": "imageBuilder",
+          "title": "Images",
+          "href": "/insights/image-builder",
+          "product": "Red Hat Insights",
+          "description": "Build and manage Red Hat Enterprise Linux images and environments."
         },
         {
-          "title": "Product Materials",
+          "title": "System Configuration",
           "expandable": true,
           "routes": [
             {
-              "id": "productMaterialDocumentation",
-              "title": "Documentation",
-              "isExternal": true,
-              "href": "https://access.redhat.com/documentation/en-us/red_hat_insights/"
+              "id": "rhc",
+              "appId": "connector",
+              "title": "Remote Host Configuration (RHC)",
+              "href": "/settings/connector",
+              "product": "Red Hat Insights",
+              "description": "Configure your systems to execute Ansible Playbooks."
             },
             {
-              "id": "securityInformation",
-              "title": "Security Information",
-              "href": "https://www.redhat.com/en/technologies/management/insights/data-application-security",
-              "isExternal": true
-            },
-            {
-              "id": "apis",
-              "appId": "apiDocs",
-              "title": "APIs",
-              "href": "/docs/api"
+              "id": "activationKeys",
+              "appId": "connector",
+              "title": "Activation keys",
+              "href": "/settings/connector/activation-keys",
+              "product": "Red Hat Insights",
+              "description": "Create activation keys to register your systems and configure repositories without using a username and password."
             }
           ]
         }


### PR DESCRIPTION
While rebasing, it seems I messed the /static/stable/prod/navigation/rhel-navigation.json

The problem is Learning resource was added into prod, Product materials nav is now duplicated. This PR resolves this situation.