### PR TITLE
[prod-*][stage-stable] fix Subscriptions OpenShift links

### DIFF
--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -280,7 +280,7 @@
               "id": "subscriptions",
               "appId": "subscriptions",
               "title": "OpenShift Subscriptions",
-              "href": "/openshift/subscriptions/openshift",
+              "href": "/openshift/subscriptions/openshift-container",
               "product": "Subscription Watch"
             },
             {

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -280,7 +280,7 @@
               "id": "subscriptions",
               "appId": "subscriptions",
               "title": "OpenShift Subscriptions",
-              "href": "/openshift/subscriptions/openshift",
+              "href": "/openshift/subscriptions/openshift-container",
               "product": "Subscription Watch"
             },
             {

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -273,7 +273,7 @@
               "id": "subscriptions",
               "appId": "subscriptions",
               "title": "OpenShift Subscriptions",
-              "href": "/openshift/subscriptions/openshift",
+              "href": "/openshift/subscriptions/openshift-container",
               "product": "Subscription Watch"
             },
             {


### PR DESCRIPTION
**Fixes Subscription linking behavior that is exposed for Subs "OpenShift" to correctly point at "openshift-container".**

Appears the "openshift" linking was migrated up by accident. Maybe it was missed earlier, but the navigation in prod was working prior to recent work. The Subs work that was exposed currently only in stage-beta with a planned move for AFTER summit.

Related Subs work
- #102 