### PR TITLE
RHCLOUD-25402: Change CI/CD to Trusted Application Pipeline in prod

### DIFF
--- a/static/beta/prod/navigation/application-pipeline-navigation.json
+++ b/static/beta/prod/navigation/application-pipeline-navigation.json
@@ -1,6 +1,6 @@
 {
   "id": "hac",
-  "title": "CI/CD",
+  "title": "Trusted Application Pipeline",
   "navItems": [
       {
         "id": "demoPlugin",


### PR DESCRIPTION
Renames "CICD" to "Trusted Application Pipeline" in the prod env navigation

Resolves https://issues.redhat.com/browse/RHCLOUD-25402