### PR TITLE
[RHCLOUD-25790] Add text to 'Containers' card

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -25,6 +25,7 @@
     "id": "containers",
     "icon": "CubeIcon",
     "title": "Containers",
+    "description": "Run your applications in a consistent and isolated environment.",
     "links": [
       {
         "title": "Create Cluster",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -25,6 +25,7 @@
     "id": "containers",
     "icon": "CubeIcon",
     "title": "Containers",
+    "description": "Run your applications in a consistent and isolated environment.",
     "links": [
       {
         "title": "Create Cluster",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -25,6 +25,7 @@
     "id": "containers",
     "icon": "CubeIcon",
     "title": "Containers",
+    "description": "Run your applications in a consistent and isolated environment.",
     "links": [
       {
         "title": "Create Cluster",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -25,6 +25,7 @@
     "id": "containers",
     "icon": "CubeIcon",
     "title": "Containers",
+    "description": "Run your applications in a consistent and isolated environment.",
     "links": [
       {
         "title": "Create Cluster",


### PR DESCRIPTION
- Based on this ticket: https://issues.redhat.com/browse/RHCLOUD-25790
- Previously, the container card had no description under it. Now it does.
- It is underlined in the screenshot below.

<img width="1430" alt="Screenshot 2023-05-18 at 4 01 59 PM" src="https://github.com/RedHatInsights/chrome-service-backend/assets/107655677/f4a5628b-0483-47aa-afdb-8395e584431c">
