### PR TITLE
[RHCLOUD-25301] Add "OpenShift" to Infrastructure description

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -81,7 +81,7 @@
     "id": "infrastructure",
     "icon": "InfrastructureIcon",
     "title": "Infrastructure",
-    "description": "Manage your infrastructure across the hybrid cloud.",
+    "description": "Manage your OpenShift infrastructure across the hybrid cloud.",
     "links": [
       "openshift.clusters",
       "openshift.overview",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -80,7 +80,7 @@
     "id": "infrastructure",
     "icon": "InfrastructureIcon",
     "title": "Infrastructure",
-    "description": "Manage your infrastructure across the hybrid cloud.",
+    "description": "Manage your OpenShift infrastructure across the hybrid cloud.",
     "links": [
       "openshift.clusters",
       "openshift.overview",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -81,7 +81,7 @@
     "id": "infrastructure",
     "icon": "InfrastructureIcon",
     "title": "Infrastructure",
-    "description": "Manage your infrastructure across the hybrid cloud.",
+    "description": "Manage your OpenShift infrastructure across the hybrid cloud.",
     "links": [
       "openshift.clusters",
       "openshift.overview",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -80,7 +80,7 @@
     "id": "infrastructure",
     "icon": "InfrastructureIcon",
     "title": "Infrastructure",
-    "description": "Manage your infrastructure across the hybrid cloud.",
+    "description": "Manage your OpenShift infrastructure across the hybrid cloud.",
     "links": [
       "openshift.clusters",
       "openshift.overview",


### PR DESCRIPTION
- The Infrastructure card description under "All Services" was updated to this: "Manage your OpenShift infrastructure across the hybrid cloud."
- Previously, the word "OpenShift" wasn't there. Now, it's been added

<img width="1430" alt="Screenshot 2023-05-18 at 4 37 50 PM" src="https://github.com/RedHatInsights/chrome-service-backend/assets/107655677/121ab743-133f-4c0a-80de-31477942fa27">
