### PR TITLE
[stage-*] Consolidate Subscription Watch RHEL, Satellite, and OpenShift displays

### DIFF
--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -103,7 +103,7 @@
                         {
                             "id": "containerPlatform",
                             "appId": "subscriptions",
-                            "title": "Container Platform",
+                            "title": "Red Hat OpenShift",
                             "href": "/openshift/subscriptions/openshift",
                             "product": "Subscription Watch"
                         },

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -103,8 +103,8 @@
                         {
                             "id": "containerPlatform",
                             "appId": "subscriptions",
-                            "title": "Container Platform",
-                            "href": "/openshift/subscriptions/openshift-container",
+                            "title": "Red Hat OpenShift",
+                            "href": "/openshift/subscriptions/openshift",
                             "product": "Subscription Watch"
                         },
                         {
@@ -112,12 +112,6 @@
                             "appId": "openshift",
                             "title": "Dedicated (Annual)",
                             "href": "/openshift/quota"
-                        },
-                        {
-                            "id": "dedicatedOnDemant",
-                            "appId": "subscriptions",
-                            "title": "Dedicated (On-Demand)",
-                            "href": "/openshift/subscriptions/openshift-dedicated"
                         },
                         {
                             "id": "dedicatedOnDemandLimits",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -274,7 +274,7 @@
               "id": "subscriptions",
               "appId": "subscriptions",
               "title": "OpenShift Subscriptions",
-              "href": "/openshift/subscriptions/openshift-container",
+              "href": "/openshift/subscriptions/openshift",
               "product": "Subscription Watch"
             },
             {


### PR DESCRIPTION
Consolidates the navigation for Subscription Watch as part of
[SWATCH-897][SWATCH-1218]

related 
- https://github.com/RedHatInsights/curiosity-frontend/pull/1098