### PR TITLE
Add trusted content to application services

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -6,7 +6,8 @@
     "title": "Application services",
     "links": [
       "application-services.apiManagement",
-      "application-services.serviceAccounts"
+      "application-services.serviceAccounts",
+      "application-services.trustedContentOverview"
     ]
   },
   {

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -6,7 +6,8 @@
     "title": "Application services",
     "links": [
       "application-services.apiManagement",
-      "application-services.serviceAccounts"
+      "application-services.serviceAccounts",
+      "application-services.trustedContentOverview"
     ]
   },
   {

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -6,7 +6,8 @@
     "title": "Application services",
     "links": [
       "application-services.apiManagement",
-      "application-services.serviceAccounts"
+      "application-services.serviceAccounts",
+      "application-services.trustedContentOverview"
     ]
   },
   {

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -6,7 +6,8 @@
     "title": "Application services",
     "links": [
       "application-services.apiManagement",
-      "application-services.serviceAccounts"
+      "application-services.serviceAccounts",
+      "application-services.trustedContentOverview"
     ]
   },
   {


### PR DESCRIPTION
### Description

Trusted content team would like to surface their application within all services page and on the new navigation. This PR adds their application to "App services section".

### JIRA

RHCLOUD-25261

### Screenshots

![Screenshot from 2023-06-02 10-50-14](https://github.com/RedHatInsights/chrome-service-backend/assets/3439771/c82032fa-65cc-4ed3-9e8a-001fee31f8e7)
![Screenshot from 2023-06-02 10-50-28](https://github.com/RedHatInsights/chrome-service-backend/assets/3439771/9ed8bdde-ef06-4605-b245-07cade91a977)

