### PR TITLE
[Merge on 6/27] Hub - remove repo management from prod

### DIFF
--- a/static/beta/prod/navigation/ansible-navigation.json
+++ b/static/beta/prod/navigation/ansible-navigation.json
@@ -29,13 +29,6 @@
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "id": "repoManagement",
-                    "appId": "automationHub",
-                    "title": "Repo Management",
-                    "href": "/ansible/automation-hub/repositories",
-                    "product": "Ansible Automation Hub"
-                },
-                {
                     "id": "taskManagement",
                     "appId": "automationHub",
                     "title": "Task Management",

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -30,13 +30,6 @@
                 },
                 {
                     "appId": "automationHub",
-                    "id": "repoManagement",
-                    "title": "Repo Management",
-                    "href": "/ansible/automation-hub/repositories",
-                    "product": "Ansible Automation Hub"
-                },
-                {
-                    "appId": "automationHub",
                     "id": "taskManagement",
                     "title": "Task Management",
                     "href": "/ansible/automation-hub/tasks",


### PR DESCRIPTION
Continues the series of #66, #75, #139.

Remove "Repo Management" Ansible Automation Hub nav from prod-beta & prod-stable.
(Already removed from stage.)

(No replacement nav items.)

Cc @Hyperkid123 

(https://issues.redhat.com/browse/AAH-2257, https://issues.redhat.com/browse/AAH-2334)