### PR TITLE
Check for nil feature flag element in Clowder config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,11 +99,13 @@ func init() {
 		options.DbSSLMode = cfg.Database.SslMode
 		options.DbSSLRootCert = options.getCert(cfg)
 
-		options.FeatureFlagConfig.ClientAccessToken = *cfg.FeatureFlags.ClientAccessToken
-		options.FeatureFlagConfig.Hostname = cfg.FeatureFlags.Hostname
-		options.FeatureFlagConfig.Scheme = string(cfg.FeatureFlags.Scheme)
-		options.FeatureFlagConfig.Port = cfg.FeatureFlags.Port
-		options.FeatureFlagConfig.FullURL = fmt.Sprintf("%s://%s:%d/api/", options.FeatureFlagConfig.Scheme, options.FeatureFlagConfig.Hostname, options.FeatureFlagConfig.Port)
+		if cfg.FeatureFlags != nil {
+			options.FeatureFlagConfig.ClientAccessToken = *cfg.FeatureFlags.ClientAccessToken
+			options.FeatureFlagConfig.Hostname = cfg.FeatureFlags.Hostname
+			options.FeatureFlagConfig.Scheme = string(cfg.FeatureFlags.Scheme)
+			options.FeatureFlagConfig.Port = cfg.FeatureFlags.Port
+			options.FeatureFlagConfig.FullURL = fmt.Sprintf("%s://%s:%d/api/", options.FeatureFlagConfig.Scheme, options.FeatureFlagConfig.Hostname, options.FeatureFlagConfig.Port)
+		}
 
 		broker := cfg.Kafka.Brokers[0]
 		// pass all required topics names

--- a/rest/featureflags/featureflags.go
+++ b/rest/featureflags/featureflags.go
@@ -25,7 +25,6 @@ func newClientWrapper(cfg *config.ChromeServiceConfig) (*unleash.Client, error) 
 		unleash.WithCustomHeaders(http.Header{"Authorization": {cfg.FeatureFlagConfig.ClientAccessToken}}),
 	)
 	if err != nil {
-		client.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
An environment encountered an issue where there was no feature flag provider. When this happens, the app fails to spin up due to the panic caused by a nil pointer. 

* Check to ensure FeatureFlag provider has given a defined config before assigning vars in the config.