### PR TITLE
Check for nil feature flag element in Clowder config 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,6 @@ infra:
 
 clean-all:
 	podman-compose -f local/full-stack-compose.yaml down
+
+test:
+	go test -v  ./...

--- a/config/config.go
+++ b/config/config.go
@@ -99,11 +99,13 @@ func init() {
 		options.DbSSLMode = cfg.Database.SslMode
 		options.DbSSLRootCert = options.getCert(cfg)
 
-		options.FeatureFlagConfig.ClientAccessToken = *cfg.FeatureFlags.ClientAccessToken
-		options.FeatureFlagConfig.Hostname = cfg.FeatureFlags.Hostname
-		options.FeatureFlagConfig.Scheme = string(cfg.FeatureFlags.Scheme)
-		options.FeatureFlagConfig.Port = cfg.FeatureFlags.Port
-		options.FeatureFlagConfig.FullURL = fmt.Sprintf("%s://%s:%d/api/", options.FeatureFlagConfig.Scheme, options.FeatureFlagConfig.Hostname, options.FeatureFlagConfig.Port)
+		if cfg.FeatureFlags != nil {
+			options.FeatureFlagConfig.ClientAccessToken = *cfg.FeatureFlags.ClientAccessToken
+			options.FeatureFlagConfig.Hostname = cfg.FeatureFlags.Hostname
+			options.FeatureFlagConfig.Scheme = string(cfg.FeatureFlags.Scheme)
+			options.FeatureFlagConfig.Port = cfg.FeatureFlags.Port
+			options.FeatureFlagConfig.FullURL = fmt.Sprintf("%s://%s:%d/api/", options.FeatureFlagConfig.Scheme, options.FeatureFlagConfig.Hostname, options.FeatureFlagConfig.Port)
+		}
 
 		broker := cfg.Kafka.Brokers[0]
 		// pass all required topics names

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func init() {
 
 func main() {
 	cfg := config.Get()
+	featureflags.Init(cfg)
 	setupLogger(cfg)
 	router := chi.NewRouter()
 	metricsRouter := chi.NewRouter()

--- a/rest/featureflags/featureflags.go
+++ b/rest/featureflags/featureflags.go
@@ -47,6 +47,7 @@ func New(cfg *config.ChromeServiceConfig) error {
 	}
 	c, err := newClientWrapper(cfg)
 	if err != nil {
+		ffClient = nil
 		logrus.Infof("Unable to contact unleash server due to: %v", err)
 		return err
 	}
@@ -68,14 +69,20 @@ func IsEnabled(flag string) bool {
 }
 
 func Close() {
-	ffClient.unleashClient.Close()
+	if ffClient != nil {
+		ffClient.unleashClient.Close()
+		ffClient = nil
+	}
 }
 
 // Called before main() and when the library is imported
-func init() {
-	cfg := config.Get()
+func Init(cfg *config.ChromeServiceConfig) {
 	err := New(cfg)
 	if err != nil {
 		logrus.Infoln("all feature flags are set to false")
 	}
+}
+
+func GetClient() *FFClient {
+	return ffClient
 }

--- a/rest/featureflags/featureflags.go
+++ b/rest/featureflags/featureflags.go
@@ -25,7 +25,6 @@ func newClientWrapper(cfg *config.ChromeServiceConfig) (*unleash.Client, error) 
 		unleash.WithCustomHeaders(http.Header{"Authorization": {cfg.FeatureFlagConfig.ClientAccessToken}}),
 	)
 	if err != nil {
-		client.Close()
 		return nil, err
 	}
 

--- a/rest/featureflags/featureflags_test.go
+++ b/rest/featureflags/featureflags_test.go
@@ -1,0 +1,52 @@
+package featureflags
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/chrome-service-backend/config"
+	"github.com/RedHatInsights/chrome-service-backend/rest/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicFeatureFlagConnection(t *testing.T) {
+	t.Run("Test accessible unleash server", func(t *testing.T) {
+		Init(util.SetupTestConfig())
+		assert.NotNil(t, GetClient())
+		Close()
+	})
+}
+
+func TestBrokenFeatureFlagConnection(t *testing.T) {
+	cfg := util.SetupTestConfig()
+	cfg.FeatureFlagConfig.FullURL = "gohawaii.com/"
+	t.Run("Connect to vacation URL", func(t *testing.T) {
+		Init(cfg)
+		assert.Empty(t, GetClient())
+		Close()
+	})
+}
+
+func TestEmptyFeatureFlagConfig(t *testing.T) {
+	cfg := util.SetupTestConfig()
+	cfg.FeatureFlagConfig = config.FeatureFlagsConfig{}
+	t.Run("Test missing FeatureFlag config", func(t *testing.T) {
+		Init(cfg)
+		assert.Nil(t, GetClient())
+		Close()
+	})
+}
+
+func TestPersistentFeatureFlagConnection(t *testing.T) {
+	t.Run("Setup basic connection", func(t *testing.T) {
+		Init(util.SetupTestConfig())
+		assert.NotNil(t, GetClient())
+	})
+	t.Run("Ensure client object is persistent", func(t *testing.T) {
+		assert.NotNil(t, GetClient())
+		assert.False(t, IsEnabled("fake.flag"))
+		Close()
+	})
+	t.Run("Client is nil after close", func(t *testing.T) {
+		assert.Nil(t, GetClient())
+	})
+}

--- a/rest/util/testutils.go
+++ b/rest/util/testutils.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/RedHatInsights/chrome-service-backend/config"
+	"github.com/joho/godotenv"
+)
+
+const ProjectName = "chrome-service-backend"
+
+func SetupTestConfig() *config.ChromeServiceConfig {
+	cfg := &config.ChromeServiceConfig{}
+	cfg.DbHost = "localhost"
+	cfg.DbUser = "chrome"
+	cfg.DbPassword = "chrome"
+	cfg.DbPort = 5432
+	cfg.DbName = "chrome"
+	cfg.FeatureFlagConfig.ClientAccessToken = "default:development.unleash-insecure-api-token"
+	cfg.FeatureFlagConfig.Hostname = "localhost"
+	cfg.FeatureFlagConfig.Scheme = "http"
+	cfg.FeatureFlagConfig.Port = 4242
+	cfg.FeatureFlagConfig.FullURL = fmt.Sprintf("%s://%s:%d/api/", cfg.FeatureFlagConfig.Scheme, cfg.FeatureFlagConfig.Hostname, cfg.FeatureFlagConfig.Port)
+	return cfg
+}
+
+// TODO: Break test config out into env files in the future
+// LoadEnv loads env vars from .env
+func LoadEnv() {
+	re := regexp.MustCompile(`^(.*` + ProjectName + `)`)
+	cwd, _ := os.Getwd()
+	rootPath := re.Find([]byte(cwd))
+
+	err := godotenv.Load(string(rootPath) + `/.env.test`)
+	if err != nil {
+		fmt.Println(err)
+	}
+}


### PR DESCRIPTION
An environment encountered an issue where there was no feature flag provider. When this happens, the app fails to spin up due to the panic caused by a nil pointer.

* Check to ensure FeatureFlag provider has given a defined config before assigning vars in the config.