### PR TITLE
Setup seed file for unleash server for better testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,11 @@ port?=8000
 dev-static:
 	go run cmd/static/static.go $(port)
 
-
 dev-static-node:
 	npx http-server . -a :: -p $(port)
 
 migrate:
 	go run cmd/migrate/migrate.go 
-
-dev:
-	go run main.go
 
 database:
 	podman-compose up
@@ -55,5 +51,11 @@ infra:
 clean-all:
 	podman-compose -f local/full-stack-compose.yaml down
 
-test:
+test: seed-unleash
 	go test -v  ./...
+
+seed-unleash:
+	go run cmd/unleash/seed.go
+
+dev: seed-unleash
+	go run main.go

--- a/cmd/unleash/featureflag.json
+++ b/cmd/unleash/featureflag.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "chrome-service.websockets.enabled",
+    "enabled": true
+  },
+  {
+    "name": "unit-test.true",
+    "enabled": true
+  },
+  {
+    "name": "unit-test.false",
+    "enabled": false
+  }
+]

--- a/cmd/unleash/seed.go
+++ b/cmd/unleash/seed.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/RedHatInsights/chrome-service-backend/config"
+	"github.com/joho/godotenv"
+)
+
+type FeatureFlag struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+const featureFlagPath = "cmd/unleash/featureflag.json"
+
+var baseUrl string
+
+func main() {
+	godotenv.Load()
+	cfg := config.Get()
+	baseUrl = fmt.Sprintf("%s%s", cfg.FeatureFlagConfig.FullURL, "admin/projects/default/features")
+	// Read JSON data from file
+	buff, err := ioutil.ReadFile(featureFlagPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Unmarshal JSON data into slice of structs
+	var flags []FeatureFlag
+	err = json.Unmarshal(buff, &flags)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, v := range flags {
+		err := createFeatureFlagEntry(v, cfg)
+		if err != nil {
+			fmt.Printf("Error: %v", err)
+			return
+		}
+		if v.Enabled {
+			err = setEnabled(v, cfg)
+			if err != nil {
+				fmt.Printf("Error: %v", err)
+				return
+			}
+		}
+	}
+
+}
+
+func createFeatureFlagEntry(f FeatureFlag, cfg *config.ChromeServiceConfig) error {
+	client := &http.Client{}
+	jsonData, err := json.Marshal(f)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	// Send HTTP request to Unleash server
+	req, err := http.NewRequest("POST", baseUrl, bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", cfg.FeatureFlagConfig.AdminToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Process response from Unleash server
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println(string(body))
+	return nil
+}
+
+func setEnabled(f FeatureFlag, cfg *config.ChromeServiceConfig) error {
+	flagUrl := fmt.Sprintf("%s/%s/environments/development/on", baseUrl, f.Name)
+	client := &http.Client{}
+	jsonData, err := json.Marshal(f)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	// Send HTTP request to Unleash server
+	req, err := http.NewRequest("POST", flagUrl, bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", cfg.FeatureFlagConfig.AdminToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	log.Printf("Flag %s set to enabled with code %d", f.Name, resp.StatusCode)
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,8 @@ type FeatureFlagsConfig struct {
 	Port              int
 	Scheme            string
 	FullURL           string
+	// ONLY for local use, Clowder won't populate this
+	AdminToken string
 }
 
 type ChromeServiceConfig struct {
@@ -149,6 +151,8 @@ func init() {
 		}
 
 		options.FeatureFlagConfig.ClientAccessToken = os.Getenv("UNLEASH_API_TOKEN")
+		// Only for local use to seed the database, does not work in Clowder.
+		options.FeatureFlagConfig.AdminToken = os.Getenv("UNLEASH_ADMIN_TOKEN")
 		options.FeatureFlagConfig.Hostname = "localhost"
 		options.FeatureFlagConfig.Scheme = "http"
 		options.FeatureFlagConfig.Port = 4242

--- a/local/full-stack-compose.yaml
+++ b/local/full-stack-compose.yaml
@@ -59,6 +59,8 @@ services:
       LOG_LEVEL: "warn"
       INIT_FRONTEND_API_TOKENS: "default:development.unleash-insecure-frontend-api-token"
       INIT_CLIENT_API_TOKENS: "default:development.unleash-insecure-api-token"
+      # This is setup to seed in feature flags, production is entirely different
+      INIT_ADMIN_API_TOKENS: "*:*.unleash-insecure-api-token"
     depends_on:
       db:
         condition: service_healthy

--- a/local/unleash-compose.yaml
+++ b/local/unleash-compose.yaml
@@ -9,19 +9,13 @@ services:
     ports:
     - "4242:4242"
     environment:
-      # This points Unleash to its backing database (defined in the `db` section below)
       DATABASE_URL: "postgres://postgres:unleash@db/postgres"
-      # Disable SSL for database connections. @chriswk: why do we do this?
       DATABASE_SSL: "false"
-      # Changing log levels:
       LOG_LEVEL: "warn"
-      # Proxy clients must use one of these keys to connect to the
-      # Proxy. To add more keys, separate them with a comma (`key1,key2`).
       INIT_FRONTEND_API_TOKENS: "default:development.unleash-insecure-frontend-api-token"
-      # Initialize Unleash with a default set of client API tokens. To
-      # initialize Unleash with multiple tokens, separate them with a
-      # comma (`token1,token2`).
       INIT_CLIENT_API_TOKENS: "default:development.unleash-insecure-api-token"
+      # This is setup to seed in feature flags, production is entirely different
+      INIT_ADMIN_API_TOKENS: "*:*.unleash-insecure-api-token"
     depends_on:
       db:
         condition: service_healthy
@@ -37,9 +31,7 @@ services:
     - "5432"
     image: postgres:15
     environment:
-      # create a database called `db`
       POSTGRES_DB: "db"
-      # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
       POSTGRES_HOST_AUTH_METHOD: "trust"
     healthcheck:
       test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]

--- a/main.go
+++ b/main.go
@@ -73,13 +73,13 @@ func main() {
 	metricsRouter.Handle("/metrics", promhttp.Handler())
 
 	go func() {
-		metricsStringAddr := fmt.Sprintf("localhost:%s", strconv.Itoa(cfg.MetricsPort))
+		metricsStringAddr := fmt.Sprintf(":%s", strconv.Itoa(cfg.MetricsPort))
 		if err := http.ListenAndServe(metricsStringAddr, metricsRouter); err != nil {
 			log.Fatalf("Metrics server stopped %v", err)
 		}
 	}()
 
-	serverStringAddr := fmt.Sprintf("localhost:%s", strconv.Itoa(cfg.WebPort))
+	serverStringAddr := fmt.Sprintf(":%s", strconv.Itoa(cfg.WebPort))
 	if err := http.ListenAndServe(serverStringAddr, router); err != nil {
 		log.Fatalf("Chrome-service-api has stopped due to %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -73,13 +73,13 @@ func main() {
 	metricsRouter.Handle("/metrics", promhttp.Handler())
 
 	go func() {
-		metricsStringAddr := fmt.Sprintf(":%s", strconv.Itoa(cfg.MetricsPort))
+		metricsStringAddr := fmt.Sprintf("localhost:%s", strconv.Itoa(cfg.MetricsPort))
 		if err := http.ListenAndServe(metricsStringAddr, metricsRouter); err != nil {
 			log.Fatalf("Metrics server stopped %v", err)
 		}
 	}()
 
-	serverStringAddr := fmt.Sprintf(":%s", strconv.Itoa(cfg.WebPort))
+	serverStringAddr := fmt.Sprintf("localhost:%s", strconv.Itoa(cfg.WebPort))
 	if err := http.ListenAndServe(serverStringAddr, router); err != nil {
 		log.Fatalf("Chrome-service-api has stopped due to %v", err)
 	}

--- a/rest/featureflags/featureflags_test.go
+++ b/rest/featureflags/featureflags_test.go
@@ -12,13 +12,19 @@ func TestBasicFeatureFlagConnection(t *testing.T) {
 	t.Run("Test accessible unleash server", func(t *testing.T) {
 		Init(util.SetupTestConfig())
 		assert.NotNil(t, GetClient())
+	})
+	t.Run("Test disabled flag is disabled", func(t *testing.T) {
+		assert.False(t, IsEnabled("unit-test.false"))
+	})
+	t.Run("Test enabled flag is enabled", func(t *testing.T) {
+		assert.True(t, IsEnabled("unit-test.true"))
 		Close()
 	})
 }
 
 func TestBrokenFeatureFlagConnection(t *testing.T) {
 	cfg := util.SetupTestConfig()
-	cfg.FeatureFlagConfig.FullURL = "gohawaii.com/"
+	cfg.FeatureFlagConfig.FullURL = "gohawaii.com"
 	t.Run("Connect to vacation URL", func(t *testing.T) {
 		Init(cfg)
 		assert.Empty(t, GetClient())
@@ -32,6 +38,8 @@ func TestEmptyFeatureFlagConfig(t *testing.T) {
 	t.Run("Test missing FeatureFlag config", func(t *testing.T) {
 		Init(cfg)
 		assert.Nil(t, GetClient())
+		// True flags should be false if the server cannot be reached
+		assert.False(t, IsEnabled("unit-test.true"))
 		Close()
 	})
 }


### PR DESCRIPTION
* Fixes a race condition in the unleash client init
* Sets up a json file that serves as a seed for the unleash database
* Adds tests for the seed file
* Adds a go cmd script to populate the feature flag database before operations
* Updates `make dev` to ensure the unleash db is seeded before running the API