### PR TITLE
[RHCLOUD-26207] Enable tests and CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,65 @@
+name: Go package
+
+on: [push]
+
+jobs:
+  pr_check:
+    runs-on: ubuntu-latest
+    services:
+        unleash-db:
+          image: postgres:15
+          options: >-
+            --health-cmd pg_isready
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+          env:
+            POSTGRES_DB: "db"
+            # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
+            POSTGRES_HOST_AUTH_METHOD: "trust"
+        chrome-db:
+          image: postgres:14.1-alpine
+          options: >-
+            --health-cmd pg_isready
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+          env:
+            POSTGRES_USER: chrome
+            POSTGRES_PASSWORD: chrome
+          ports:
+            - "5432:5432"
+
+        unleash_web:
+          image: unleashorg/unleash-server:latest
+          options: >-
+            --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1"
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+            --health-start-period 30s
+          ports:
+            - "4242:4242"
+          env:
+            DATABASE_URL: "postgres://postgres:unleash@unleash-db/postgres"
+            DATABASE_SSL: "false"
+            LOG_LEVEL: "warn"
+            INIT_FRONTEND_API_TOKENS: "default:development.unleash-insecure-frontend-api-token"
+            INIT_CLIENT_API_TOKENS: "default:development.unleash-insecure-api-token"
+            # This is set up to seed in feature flags, production is entirely different
+            INIT_ADMIN_API_TOKENS: "*:*.unleash-insecure-api-token"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.18'
+
+      - name: 'Create env file'
+        run: |
+          echo "${{ secrets.ENV_FILE }}" > .env
+
+      - name: Test
+        run: make test

--- a/config/config.go
+++ b/config/config.go
@@ -153,7 +153,7 @@ func init() {
 		options.FeatureFlagConfig.ClientAccessToken = os.Getenv("UNLEASH_API_TOKEN")
 		// Only for local use to seed the database, does not work in Clowder.
 		options.FeatureFlagConfig.AdminToken = os.Getenv("UNLEASH_ADMIN_TOKEN")
-		options.FeatureFlagConfig.Hostname = "localhost"
+		options.FeatureFlagConfig.Hostname = "0.0.0.0"
 		options.FeatureFlagConfig.Scheme = "http"
 		options.FeatureFlagConfig.Port = 4242
 		options.FeatureFlagConfig.FullURL = fmt.Sprintf("%s://%s:%d/api/", options.FeatureFlagConfig.Scheme, options.FeatureFlagConfig.Hostname, options.FeatureFlagConfig.Port)

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -26,7 +26,8 @@ cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
 </testsuite>
 EOF
 
+# Build and publish container image
 source $CICD_ROOT/build.sh
-# temporarily exit early to sucesfully deploy the image to quay
-exit 0
+
+## Roll out ephemeral env
 source $CICD_ROOT/deploy_ephemeral_env.sh


### PR DESCRIPTION
* Sets up GitHub Actions to run the "unit tests". Since they require an admin token from unleash, we cannot use ephemeral yet.
* Deploys the app to ephemeral and ensures it will come up correctly. 