### PR TITLE
Read from latest offset in kafka topic

### DIFF
--- a/rest/kafka/consumers.go
+++ b/rest/kafka/consumers.go
@@ -94,6 +94,8 @@ func createReader(topic string) *kafka.Reader {
 	config := config.Get()
 	r := kafka.NewReader(kafka.ReaderConfig{
 		Brokers:     config.KafkaConfig.KafkaBrokers,
+		GroupID:     "platform.chrome",
+		StartOffset: kafka.LastOffset,
 		Topic:       topic,
 		Logger:      kafka.LoggerFunc(logrus.Debugf),
 		ErrorLogger: kafka.LoggerFunc(logrus.Errorf),


### PR DESCRIPTION
The default option on the segment reader is to grab offset 0 and read forward each time the app comes up. We instead only want to read the current offset to read new messages without logging all the old ones too. 