### PR TITLE
Add permissions logic to HCS overview link for stage-beta

### DIFF
--- a/static/beta/stage/navigation/business-services-navigation.json
+++ b/static/beta/stage/navigation/business-services-navigation.json
@@ -14,7 +14,16 @@
             "id": "overview",
             "appId": "hybridCommittedSpend",
             "title": "Overview",
-            "href": "/business-services/hybrid-committed-spend"
+            "href": "/business-services/hybrid-committed-spend",
+            "permissions": [
+              {
+                "method": "apiRequest",
+                "args": [{
+                  "url": "https://billing.qa.api.redhat.com/v1/authorization/hcsEnrollment",
+                  "accessor": "hcsDeal"
+                }]
+              }
+            ]
           },
           {
             "id": "details",


### PR DESCRIPTION
Consoledot added permissions logic to the HCS overview link for stage-stable and prod-beta. However, this logic is missing from stage-beta