### PR TITLE
Move Learning Resources to Product Materials

### DIFF
--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -343,20 +343,14 @@
       "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
     },
     {
-      "id": "learningResources",
-      "appId": "learningResources",
-      "title": "Learning Resources",
-      "href": "/insights/learning-resources"
-    },
-    {
       "title": "Product Materials",
       "expandable": true,
       "routes": [
         {
-          "id": "productMaterialDocumentation",
-          "title": "Documentation",
-          "isExternal": true,
-          "href": "https://access.redhat.com/documentation/en-us/red_hat_insights/"
+          "id": "learningResources",
+          "appId": "learningResources",
+          "title": "Learning Resources",
+          "href": "/insights/learning-resources"
         },
         {
           "id": "securityInformation",


### PR DESCRIPTION
A request was made to move Learning Resources as a sub-item under Product Materials and remove Documentation because Learning Resources includes documentation.

This PR is just to get it in stage-beta and confirm we have it correct before pushing to other environments.