### PR TITLE
GH Actions hotfix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-  # This can be a security risk, but our vars are container defaults with no data
-  pull_request_target:
 
 jobs:
   pr_check:
@@ -63,9 +61,9 @@ jobs:
         with:
           go-version: '1.18'
 
-      - name: 'Create env file'
+      - name: 'Create env test file'
         run: |
-          echo "${{ env.ENV_FILE }}" > .env
+          cat ./env.actions > .env
 
       - name: Test
         run: make test

--- a/env.actions
+++ b/env.actions
@@ -1,0 +1,7 @@
+PGSQL_USER=chrome
+PGSQL_PASSWORD=chrome
+PGSQL_HOSTNAME=0.0.0.0
+PGSQL_PORT=5432
+PGSQL_DATABASE=postgres
+UNLEASH_API_TOKEN=default:development.unleash-insecure-api-token
+UNLEASH_ADMIN_TOKEN=*:*.unleash-insecure-api-token

--- a/rest/util/testutils.go
+++ b/rest/util/testutils.go
@@ -2,11 +2,7 @@ package util
 
 import (
 	"fmt"
-	"os"
-	"regexp"
-
 	"github.com/RedHatInsights/chrome-service-backend/config"
-	"github.com/joho/godotenv"
 )
 
 const ProjectName = "chrome-service-backend"
@@ -24,17 +20,4 @@ func SetupTestConfig() *config.ChromeServiceConfig {
 	cfg.FeatureFlagConfig.Port = 4242
 	cfg.FeatureFlagConfig.FullURL = fmt.Sprintf("%s://%s:%d/api/", cfg.FeatureFlagConfig.Scheme, cfg.FeatureFlagConfig.Hostname, cfg.FeatureFlagConfig.Port)
 	return cfg
-}
-
-// TODO: Break test config out into env files in the future
-// LoadEnv loads env vars from .env
-func LoadEnv() {
-	re := regexp.MustCompile(`^(.*` + ProjectName + `)`)
-	cwd, _ := os.Getwd()
-	rootPath := re.Find([]byte(cwd))
-
-	err := godotenv.Load(string(rootPath) + `/.env.test`)
-	if err != nil {
-		fmt.Println(err)
-	}
 }


### PR DESCRIPTION
Since GH actions don't deliver variables to forked pull requests, I've added an env file containing them. These variables are only fake test data and are not sensitive. They do not correlate to any real production keys or values. 