### PR TITLE
HCS UI - Remove "overview" permissions for stage-beta

### DIFF
--- a/static/beta/stage/navigation/business-services-navigation.json
+++ b/static/beta/stage/navigation/business-services-navigation.json
@@ -14,16 +14,7 @@
             "id": "overview",
             "appId": "hybridCommittedSpend",
             "title": "Overview",
-            "href": "/business-services/hybrid-committed-spend",
-            "permissions": [
-              {
-                "method": "apiRequest",
-                "args": [{
-                  "url": "https://billing.qa.api.redhat.com/v1/authorization/hcsEnrollment",
-                  "accessor": "hcsDeal"
-                }]
-              }
-            ]
+            "href": "/business-services/hybrid-committed-spend"
           },
           {
             "id": "details",


### PR DESCRIPTION
Temporarily removing "Overview" permissions as workaround for [RHCLOUD-26924](https://issues.redhat.com/browse/RHCLOUD-26924). 

QE testing is currently blocked because certain users only exist in the `billing.stage.api` environment. Using `billing.qa.api` for all incorrectly omits the "overview" nav link for these users.