### PR TITLE
use credit card icon for services for now

### DIFF
--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -261,7 +261,7 @@
   },
   {
     "id": "subscription-services",
-    "icon": "ShoppingCartIcon",
+    "icon": "CreditCardIcon",
     "title": "Subscription Services",
     "description": "Subscription Services empower buying decisions. SaMS provides software usage reporting that is designed to make your subscription choices data-driven.",
     "link": [


### PR DESCRIPTION
Need to temporarily use credit card icon for Subscriptions tile

part of [RHCLOUD-25606](https://issues.redhat.com/browse/RHCLOUD-25606)