### PR TITLE
[RHIF-209] Move Repositories and RHC from Settings to Insights - Production

### DIFF
--- a/static/beta/prod/modules/fed-modules.json
+++ b/static/beta/prod/modules/fed-modules.json
@@ -144,7 +144,7 @@
                 "module": "./RootApp",
                 "routes": [
                     {
-                        "pathname": "/settings/connector"
+                        "pathname": "/insights/connector"
                     }
                 ]
             }

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -53,7 +53,7 @@
               "id": "rhc",
               "appId": "connector",
               "title": "Remote Host Configuration (RHC)",
-              "href": "/settings/connector",
+              "href": "/insights/connector",
               "product": "Red Hat Insights",
               "description": "Configure your systems to execute Ansible Playbooks."
             },
@@ -61,7 +61,7 @@
               "id": "activationKeys",
               "appId": "connector",
               "title": "Activation keys",
-              "href": "/settings/connector/activation-keys",
+              "href": "/insights/connector/activation-keys",
               "product": "Red Hat Insights",
               "description": "Create activation keys to register your systems and configure repositories without using a username and password."
             }
@@ -88,9 +88,10 @@
           "product": "Red Hat Insights"
         },
         {
+          "id": "repositories",
           "appId": "contentSources",
           "title": "Repositories",
-          "href": "/settings/content",
+          "href": "/insights/content",
           "product": "Red Hat Insights",
           "isBeta": true
         },

--- a/static/beta/prod/navigation/settings-navigation.json
+++ b/static/beta/prod/navigation/settings-navigation.json
@@ -34,12 +34,6 @@
             ]
         },
         {
-            "id": "repositories",
-            "appId": "contentSources",
-            "title": "Repositories",
-            "href": "/settings/content"
-        },
-        {
             "id": "integrations",
             "appId": "notifications",
             "title": "Integrations",
@@ -68,26 +62,6 @@
                     "title": "Console",
                     "description": "Configure which notifications users within your organization receive.",
                     "href": "/settings/notifications/console"
-                }
-            ]
-        },
-        {
-            "title": "Remote Host Configuration",
-            "expandable": true,
-            "routes": [
-                {
-                    "id": "manageConfiguration",
-                    "appId": "connector",
-                    "title": "Manage configuration",
-                    "href": "/settings/connector",
-                    "description": "Configure your systems to execute Ansible Playbooks."
-                },
-                {
-                    "id": "activationKeys",
-                    "appId": "connector",
-                    "title": "Activation Keys",
-                    "href": "/settings/connector/activation-keys",
-                    "description": "Create activation keys to register your systems and configure repositories without using a username and password."
                 }
             ]
         },

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -68,7 +68,7 @@
         "description": "Manage the lifecycle and enhance security of your RHEL systems at the edge."
       },
       "rhel.imageBuilder",
-      "settings.repositories",
+      "rhel.repositories",
       "quay.quay"
     ]
   },
@@ -254,7 +254,7 @@
     "title": "System Configuration",
     "description": "Connect your RHEL systems to Hybrid Cloud Console services.",
     "links": [
-      "settings.activationKeys",
+      "rhel.activationKeys",
       "rhel.manifests",
       "rhel.registerSystems",
       "settings.manageConfiguration"

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -153,7 +153,7 @@
                 "module": "./RootApp",
                 "routes": [
                     {
-                        "pathname": "/settings/connector"
+                        "pathname": "/insights/connector"
                     }
                 ]
             }

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -53,7 +53,7 @@
               "id": "rhc",
               "appId": "connector",
               "title": "Remote Host Configuration (RHC)",
-              "href": "/settings/connector",
+              "href": "/insights/connector",
               "product": "Red Hat Insights",
               "description": "Configure your systems to execute Ansible Playbooks."
             },
@@ -61,7 +61,7 @@
               "id": "activationKeys",
               "appId": "connector",
               "title": "Activation keys",
-              "href": "/settings/connector/activation-keys",
+              "href": "/insights/connector/activation-keys",
               "product": "Red Hat Insights",
               "description": "Create activation keys to register your systems and configure repositories without using a username and password."
             }
@@ -88,9 +88,10 @@
           "product": "Red Hat Insights"
         },
         {
+          "id": "repositories",
           "appId": "contentSources",
           "title": "Repositories",
-          "href": "/settings/content",
+          "href": "/insights/content",
           "product": "Red Hat Insights",
           "isBeta": true
         },

--- a/static/stable/prod/navigation/settings-navigation.json
+++ b/static/stable/prod/navigation/settings-navigation.json
@@ -66,26 +66,6 @@
             ]
         },
         {
-            "title": "Remote Host Configuration",
-            "expandable": true,
-            "routes": [
-                {
-                    "id": "manageConfiguration",
-                    "appId": "connector",
-                    "title": "Manage configuration",
-                    "href": "/settings/connector",
-                    "description": "Configure your systems to execute Ansible Playbooks."
-                },
-                {
-                    "id": "activationKeys",
-                    "appId": "connector",
-                    "title": "Activation Keys",
-                    "href": "/settings/connector/activation-keys",
-                    "description": "Create activation keys to register your systems and configure repositories without using a username and password."
-                }
-            ]
-        },
-        {
             "title": "Applications",
             "expandable": true,
             "permissions": [

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -68,7 +68,7 @@
         "description": "Manage the lifecycle and enhance security of your RHEL systems at the edge."
       },
       "rhel.imageBuilder",
-      "settings.repositories",
+      "rhel.repositories",
       "quay.quay"
     ]
   },
@@ -253,7 +253,7 @@
     "title": "System Configuration",
     "description": "Connect your RHEL systems to Hybrid Cloud Console services.",
     "links": [
-      "settings.activationKeys",
+      "rhel.activationKeys",
       "rhel.manifests",
       "rhel.registerSystems",
       "settings.manageConfiguration"


### PR DESCRIPTION
Ticket: [RHIF-209](https://issues.redhat.com/browse/RHIF-209)

Production part of this [Stage PR](https://github.com/RedHatInsights/chrome-service-backend/pull/195)

Would be amazing if this would be merged together with the [redirect](https://issues.redhat.com/browse/RHCLOUD-27413)