### PR TITLE
[HMS-2031] feat: configuration for Directory and Domain Service

### DIFF
--- a/static/beta/stage/main.yml
+++ b/static/beta/stage/main.yml
@@ -96,6 +96,13 @@ edge:
       - v1
     isBeta: true
 
+idmsvc:
+  title: "Directory & Domain Services"
+  api:
+    versions:
+      - v1
+    isBeta: true
+
 image-builder:
   title: Image Builder
   api:

--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1005,6 +1005,21 @@
             }
         ]
     },
+    "idmsvc": {
+        "manifestLocation": "/apps/idmsvc/fed-mods.json",
+        "defaultDocumentTitle": "Directory & Domain Services",
+        "modules": [
+            {
+                "id": "idmsvc",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/settings/idmsvc"
+                    }
+                ]
+            }
+        ]
+    },
     "seatsAdminUi": {
         "manifestLocation": "/apps/seats-admin-ui/fed-mods.json",
         "config": {

--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -46,6 +46,13 @@
             ]
         },
         {
+            "id": "idmsvc",
+            "appId": "idmsvc",
+            "title": "Directory & Domain Services",
+            "description": "Directory and Domain Services for console.redhat.com",
+            "href": "/settings/idmsvc"
+        },
+        {
             "id": "integrations",
             "appId": "notifications",
             "title": "Integrations",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -390,6 +390,7 @@
       "rhel.activationKeys",
       "rhel.manifests",
       "rhel.registerSystems",
+      "settings.idmsvc",
       "settings.manageConfiguration",
       {
         "href": "/insights/connector",


### PR DESCRIPTION
Add the configuration to make available "Directory & Domain Services" at stage beta environment. The micro-frontend will be accessible from the Settings section, and "Directory & Domain Services" will be the entry to display.