### PR TITLE
Update learning resources path in stage

### DIFF
--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -904,7 +904,7 @@
       ]
   },
   "learningResources": {
-      "manifestLocation": "/apps/learningResources/fed-mods.json",
+      "manifestLocation": "/apps/learning-resources/fed-mods.json",
       "modules": [
           {
               "id": "learningResources",


### PR DESCRIPTION
* Fixes a stage issue where `/apps/learningResources` returns errors. The corrected path is `/apps/learning-resources`