### PR TITLE
Remove HCS permission check

### DIFF
--- a/static/beta/prod/navigation/business-services-navigation.json
+++ b/static/beta/prod/navigation/business-services-navigation.json
@@ -14,16 +14,7 @@
             "id": "overview",
             "appId": "hybridCommittedSpend",
             "title": "Overview",
-            "href": "/business-services/hybrid-committed-spend",
-            "permissions": [
-              {
-                "method": "apiRequest",
-                "args": [{
-                  "url": " https://console.redhat.com/api/billing/v1/authorization/hcsEnrollment",
-                  "accessor": "hcsDeal"
-                }]
-              }
-            ]
+            "href": "/business-services/hybrid-committed-spend"
           },
           {
             "id": "details",

--- a/static/stable/stage/navigation/business-services-navigation.json
+++ b/static/stable/stage/navigation/business-services-navigation.json
@@ -14,16 +14,7 @@
             "id": "overview",
             "appId": "hybridCommittedSpend",
             "title": "Overview",
-            "href": "/business-services/hybrid-committed-spend",
-            "permissions": [
-              {
-                "method": "apiRequest",
-                "args": [{
-                  "url": "https://console.stage.redhat.com/api/billing/v1/authorization/hcsEnrollment",
-                  "accessor": "hcsDeal"
-                }]
-              }
-            ]
+            "href": "/business-services/hybrid-committed-spend"
           },
           {
             "id": "details",


### PR DESCRIPTION
The HCS team decided to remove the permissions check from the Chrome nav, due to the 400 status errors with the api/billing proxy in prod. Although, we may add an RBAC permissions check in the near future.

The team understands the HCS card will be visible in the "Services" landing page. However, the HCS UI uses the same permissions check for its own pages (i.e., we show an empty state for non-HCS users). The behavior would be similar to Cost Management.

That said, we will continue to use the proxy for the API calls made by the HCS UI itself.
We only wish to omit the hcsEnrollment API request from the Chrome nav.

Related to https://issues.redhat.com/browse/HCS-222