### PR TITLE
Add scope to HCS module (stage)

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -945,6 +945,11 @@
     },
     "hybridCommittedSpend": {
         "manifestLocation": "/apps/hybrid-committed-spend/fed-mods.json",
+        "config": {
+            "ssoScopes": [
+                "api.billing.hcs_reports"
+            ]
+        },
         "modules": [
             {
                 "id": "hybrid-committed-spend",

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -859,6 +859,11 @@
   },
   "hybridCommittedSpend": {
       "manifestLocation": "/apps/hybrid-committed-spend/fed-mods.json",
+      "config": {
+        "ssoScopes": [
+            "api.billing.hcs_reports"
+        ]
+      },
       "modules": [
           {
               "id": "hybrid-committed-spend",


### PR DESCRIPTION
Hi,

Console is hitting some endpoints exposed by one of our applications (billing.api.redhat.com). We're currently updating the authorization algorithm in order to only allow requests having scope `api.billing.hcs_reports`; changes in this PR should tell the client to request the proper scope when retrieving a JWT (at least, that's how I understand the `config.ssoScopes` property works).

See https://issues.redhat.com/browse/ITEAIFIN-2304

Thanks,

lorenzo