### PR TITLE
feat(RHINGENG-1298): Learning Resources Updates

### DIFF
--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -591,28 +591,12 @@
       "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
     },
     {
-      "title": "Product Materials",
-      "expandable": true,
-      "routes": [
-        {
-          "id": "learningResources",
-          "appId": "learningResources",
-          "title": "Learning Resources",
-          "href": "/insights/learning-resources"
-        },
-        {
-          "id": "securityInformation",
-          "title": "Security Information",
-          "href": "https://www.redhat.com/en/technologies/management/insights/data-application-security",
-          "isExternal": true
-        },
-        {
-          "id": "apis",
-          "appId": "apiDocs",
-          "title": "APIs",
-          "href": "/docs/api"
-        }
-      ]
+      "id": "learningResources",
+      "appId": "learningResources",
+      "title": "Learning Resources",
+      "filterable": false,
+      "href": "/insights/learning-resources",
+      "product": "Red Hat Insights"
     }
   ]
 }

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -591,28 +591,12 @@
       "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
     },
     {
-      "title": "Product Materials",
-      "expandable": true,
-      "routes": [
-        {
-          "id": "learningResources",
-          "appId": "learningResources",
-          "title": "Learning Resources",
-          "href": "/insights/learning-resources"
-        },
-        {
-          "id": "securityInformation",
-          "title": "Security Information",
-          "href": "https://www.redhat.com/en/technologies/management/insights/data-application-security",
-          "isExternal": true
-        },
-        {
-          "id": "apis",
-          "appId": "apiDocs",
-          "title": "APIs",
-          "href": "/docs/api"
-        }
-      ]
+      "id": "learningResources",
+      "appId": "learningResources",
+      "title": "Learning Resources",
+      "filterable": false,
+      "href": "/insights/learning-resources",
+      "product": "Red Hat Insights"
     }
   ]
 }

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -592,28 +592,12 @@
       "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
     },
     {
-      "title": "Product Materials",
-      "expandable": true,
-      "routes": [
-        {
-          "id": "learningResources",
-          "appId": "learningResources",
-          "title": "Learning Resources",
-          "href": "/insights/learning-resources"
-        },
-        {
-          "id": "securityInformation",
-          "title": "Security Information",
-          "href": "https://www.redhat.com/en/technologies/management/insights/data-application-security",
-          "isExternal": true
-        },
-        {
-          "id": "apis",
-          "appId": "apiDocs",
-          "title": "APIs",
-          "href": "/docs/api"
-        }
-      ]
+      "id": "learningResources",
+      "appId": "learningResources",
+      "title": "Learning Resources",
+      "filterable": false,
+      "href": "/insights/learning-resources",
+      "product": "Red Hat Insights"
     }
   ]
 }

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -592,28 +592,12 @@
       "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
     },
     {
-      "title": "Product Materials",
-      "expandable": true,
-      "routes": [
-        {
-          "id": "learningResources",
-          "appId": "learningResources",
-          "title": "Learning Resources",
-          "href": "/insights/learning-resources"
-        },
-        {
-          "id": "securityInformation",
-          "title": "Security Information",
-          "href": "https://www.redhat.com/en/technologies/management/insights/data-application-security",
-          "isExternal": true
-        },
-        {
-          "id": "apis",
-          "appId": "apiDocs",
-          "title": "APIs",
-          "href": "/docs/api"
-        }
-      ]
+      "id": "learningResources",
+      "appId": "learningResources",
+      "title": "Learning Resources",
+      "filterable": false,
+      "href": "/insights/learning-resources",
+      "product": "Red Hat Insights"
     }
   ]
 }


### PR DESCRIPTION
This PR implements https://issues.redhat.com/browse/RHINENG-1298 

This PR should: 
Remove menu navigation link for "Security information"
Remove menu navigation link for "APIs"
Promote "learning resources" item up a navigation level 
Remove  "Product Materials" as there are no items listed under it anymore. 