### PR TITLE
Add service accounts to fed mods config

### DIFF
--- a/static/beta/prod/modules/fed-modules.json
+++ b/static/beta/prod/modules/fed-modules.json
@@ -877,6 +877,20 @@
             }
         ]
     },
+    "serviceAccounts": {
+      "manifestLocation": "/apps/service-accounts/fed-mods.json",
+      "modules": [
+          {
+              "id": "service-accounts",
+              "module": "./RootApp",
+              "routes": [
+                  {
+                      "pathname": "/iam/service-accounts"
+                  }
+              ]
+          }
+      ]
+    },
     "quay-ui-plugin": {
         "manifestLocation": "/apps/quay/plugin-manifest.json",
         "modules": [

--- a/static/beta/prod/navigation/iam-navigation.json
+++ b/static/beta/prod/navigation/iam-navigation.json
@@ -77,6 +77,18 @@
       ]
     },
     {
+      "id": "serviceAccounts",
+      "title": "Service Accounts",
+      "appId": "serviceAccounts",
+      "href": "/iam/service-accounts",
+      "permissions": [
+        {
+          "method": "featureFlag",
+          "args": ["platform.iam.service-accounts", true]
+        }
+      ]
+    },
+    {
       "id": "learningResources",
       "appId": "learningResources",
       "title": "Learning Resources",


### PR DESCRIPTION
### Description

Let's add service accounts to prod-preview environment. Since the app is not yet available on Akamai we'll have to hide it in the nav behind `platform.iam.service-accounts` feature flag.