### PR TITLE
Add feature flag for Cost management settings page

### DIFF
--- a/static/beta/prod/navigation/settings-navigation.json
+++ b/static/beta/prod/navigation/settings-navigation.json
@@ -106,6 +106,10 @@
                             "args": [
                                 "cost_management"
                             ]
+                        },
+                        {
+                            "method": "featureFlag",
+                            "args": ["cost-management.ui.nav.settings", false]
                         }
                     ]
                 }

--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -108,7 +108,7 @@
                         {
                             "method": "featureFlag",
                             "args": ["platform.notifications.overhaul", false]
-                        }   
+                        }
                     ]
                 },
                 {
@@ -193,6 +193,10 @@
                                     "cost-management:*:*"
                                 ]
                             ]
+                        },
+                        {
+                            "method": "featureFlag",
+                            "args": ["cost-management.ui.nav.settings", false]
                         }
                     ]
                 }

--- a/static/stable/prod/navigation/settings-navigation.json
+++ b/static/stable/prod/navigation/settings-navigation.json
@@ -106,6 +106,10 @@
                             "args": [
                                 "cost_management"
                             ]
+                        },
+                        {
+                            "method": "featureFlag",
+                            "args": ["cost-management.ui.nav.settings", false]
                         }
                     ]
                 }

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -85,7 +85,7 @@
         },
         {
             "title": "Applications",
-            "expandable": true,            
+            "expandable": true,
             "permissions": [
                 {
                     "method": "hasPermissions",
@@ -115,6 +115,10 @@
                                     "cost-management:*:*"
                                 ]
                             ]
+                        },
+                        {
+                            "method": "featureFlag",
+                            "args": ["cost-management.ui.nav.settings", false]
                         }
                     ]
                 }
@@ -126,6 +130,6 @@
             "title": "Learning Resources",
             "href": "/settings/learning-resources"
         }
-        
+
     ]
 }


### PR DESCRIPTION
The functionality within the Cost Management settings page is moving. The Cost management team would like to enable new pages within the UI tomorrow.

This update adds a temporary feature flag to disable the existing settings page navigation link, while the new feature is enabled in Cost Management. The old navigation link will be removed completely if all goes well.

https://issues.redhat.com/browse/COST-3307