### PR TITLE
Add scope to HCS module (prod)

### DIFF
--- a/static/beta/prod/modules/fed-modules.json
+++ b/static/beta/prod/modules/fed-modules.json
@@ -780,6 +780,11 @@
     },
     "hybridCommittedSpend": {
         "manifestLocation": "/apps/hybrid-committed-spend/fed-mods.json",
+        "config": {
+            "ssoScopes": [
+                "api.billing.hcs_reports"
+            ]
+        },
         "modules": [
             {
                 "id": "hybrid-committed-spend",


### PR DESCRIPTION
Hi,

this is a follow up to https://github.com/RedHatInsights/chrome-service-backend/pull/253/commits; we tested the change in preprod and everything is working as expected, requests performed by console.redhat.com are sending the expected scope.
Our US (https://issues.redhat.com/browse/ITEAIFIN-2304) mentions that we should also create an MR for `static/stable/prod/modules/fed-modules.json` but I see that the `hybridCommittedSpend` module is not defined there, I'm not sure if that's expected.

Thanks,

lorenzo

