### PR TITLE
Remove Applications nav now that Cost Management settings has moved

### DIFF
--- a/static/beta/prod/navigation/settings-navigation.json
+++ b/static/beta/prod/navigation/settings-navigation.json
@@ -84,38 +84,6 @@
             ]
         },
         {
-            "title": "Applications",
-            "expandable": true,
-            "permissions": [
-                {
-                    "method": "isOrgAdmin",
-                    "apps": [
-                        "cost-management"
-                    ]
-                }
-            ],
-            "routes": [
-                {
-                    "id": "costManagement",
-                    "appId": "applications",
-                    "title": "Cost Management",
-                    "href": "/settings/applications/cost-management",
-                    "permissions": [
-                        {
-                            "method": "isEntitled",
-                            "args": [
-                                "cost_management"
-                            ]
-                        },
-                        {
-                            "method": "featureFlag",
-                            "args": ["cost-management.ui.nav.settings", false]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             "id": "learningResources",
             "appId": "learningResources",
             "title": "Learning Resources",

--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -160,47 +160,6 @@
                     ]
                 }
             ]
-        },
-        {
-            "title": "Applications",
-            "expandable": true,
-            "permissions": [
-                {
-                    "method": "hasPermissions",
-                    "apps": [
-                        "cost-management:*:*",
-                        "advisor:*:*"
-                    ]
-                }
-            ],
-            "routes": [
-                {
-                    "id": "costManagement",
-                    "appId": "applications",
-                    "title": "Cost Management",
-                    "href": "/settings/applications/cost-management",
-                    "permissions": [
-                        {
-                            "method": "isEntitled",
-                            "args": [
-                                "cost_management"
-                            ]
-                        },
-                        {
-                            "method": "hasPermissions",
-                            "args": [
-                                [
-                                    "cost-management:*:*"
-                                ]
-                            ]
-                        },
-                        {
-                            "method": "featureFlag",
-                            "args": ["cost-management.ui.nav.settings", false]
-                        }
-                    ]
-                }
-            ]
         }
     ]
 }

--- a/static/stable/prod/navigation/settings-navigation.json
+++ b/static/stable/prod/navigation/settings-navigation.json
@@ -84,38 +84,6 @@
             ]
         },
         {
-            "title": "Applications",
-            "expandable": true,
-            "permissions": [
-                {
-                    "method": "isOrgAdmin",
-                    "apps": [
-                        "cost-management"
-                    ]
-                }
-            ],
-            "routes": [
-                {
-                    "id": "costManagement",
-                    "appId": "applications",
-                    "title": "Cost Management",
-                    "href": "/settings/applications/cost-management",
-                    "permissions": [
-                        {
-                            "method": "isEntitled",
-                            "args": [
-                                "cost_management"
-                            ]
-                        },
-                        {
-                            "method": "featureFlag",
-                            "args": ["cost-management.ui.nav.settings", false]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             "id": "learningResources",
             "appId": "learningResources",
             "title": "Learning Resources",

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -84,47 +84,6 @@
             ]
         },
         {
-            "title": "Applications",
-            "expandable": true,
-            "permissions": [
-                {
-                    "method": "hasPermissions",
-                    "apps": [
-                        "cost-management:*:*",
-                        "advisor:*:*"
-                    ]
-                }
-            ],
-            "routes": [
-                {
-                    "id": "costManagement",
-                    "appId": "applications",
-                    "title": "Cost Management",
-                    "href": "/settings/applications/cost-management",
-                    "permissions": [
-                        {
-                            "method": "isEntitled",
-                            "args": [
-                                "cost_management"
-                            ]
-                        },
-                        {
-                            "method": "hasPermissions",
-                            "args": [
-                                [
-                                    "cost-management:*:*"
-                                ]
-                            ]
-                        },
-                        {
-                            "method": "featureFlag",
-                            "args": ["cost-management.ui.nav.settings", false]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             "id": "learningResources",
             "appId": "learningResources",
             "title": "Learning Resources",


### PR DESCRIPTION
Spoke to Kathryn Dixon about removing the "Applications" toggle from the settings nav.

The functionality within the Cost Management settings page has moved. Don't want to have an empty "Applications" toggle.

https://issues.redhat.com/browse/COST-3307
