### PR TITLE
Clean up obsolete Unleash flags for Cost Management

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -208,19 +208,6 @@
                             "product": "Red Hat Cost Management"
                         },
                         {
-                            "id": "costModels",
-                            "appId": "costManagement",
-                            "title": "Cost Models",
-                            "href": "/openshift/cost-management/cost-models",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", false]
-                                }
-                            ]
-                        },
-                        {
                             "id": "costExplorer",
                             "appId": "costManagement",
                             "title": "Cost Explorer",
@@ -232,13 +219,7 @@
                             "appId": "costManagement",
                             "title": "Settings",
                             "href": "/openshift/cost-management/settings",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", true]
-                                }
-                            ]
+                            "product": "Red Hat Cost Management"
                         }
                     ]
                 }

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -199,19 +199,6 @@
                             "product": "Red Hat Cost Management"
                         },
                         {
-                            "id": "costModels",
-                            "appId": "costManagement",
-                            "title": "Cost Models",
-                            "href": "/openshift/cost-management/cost-models",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", false]
-                                }
-                            ]
-                        },
-                        {
                             "id": "costExplorer",
                             "appId": "costManagement",
                             "title": "Cost Explorer",
@@ -223,13 +210,7 @@
                             "appId": "costManagement",
                             "title": "Settings",
                             "href": "/openshift/cost-management/settings",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", true]
-                                }
-                            ]
+                            "product": "Red Hat Cost Management"
                         }
                     ]
                 }

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -208,19 +208,6 @@
                             "product": "Red Hat Cost Management"
                         },
                         {
-                            "id": "costModels",
-                            "appId": "costManagement",
-                            "title": "Cost Models",
-                            "href": "/openshift/cost-management/cost-models",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", false]
-                                }
-                            ]
-                        },
-                        {
                             "id": "costExplorer",
                             "appId": "costManagement",
                             "title": "Cost Explorer",
@@ -232,13 +219,7 @@
                             "appId": "costManagement",
                             "title": "Settings",
                             "href": "/openshift/cost-management/settings",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", true]
-                                }
-                            ]
+                            "product": "Red Hat Cost Management"
                         }
                     ]
                 }

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -199,19 +199,6 @@
                             "product": "Red Hat Cost Management"
                         },
                         {
-                            "id": "costModels",
-                            "appId": "costManagement",
-                            "title": "Cost Models",
-                            "href": "/openshift/cost-management/cost-models",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", false]
-                                }
-                            ]
-                        },
-                        {
                             "id": "costExplorer",
                             "appId": "costManagement",
                             "title": "Cost Explorer",
@@ -223,13 +210,7 @@
                             "appId": "costManagement",
                             "title": "Settings",
                             "href": "/openshift/cost-management/settings",
-                            "product": "Red Hat Cost Management",
-                            "permissions": [
-                                {
-                                    "method": "featureFlag",
-                                    "args": ["cost-management.ui.nav.settings", true]
-                                }
-                            ]
+                            "product": "Red Hat Cost Management"
                         }
                     ]
                 }


### PR DESCRIPTION
"Cost models" has been replaced by our new settings page, so we no longer need the Unleash flags.