### PR TITLE
fix(ESSNTL-5007): Update nav item from culling to deletion

### DIFF
--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -131,12 +131,12 @@
               ]
             },
             {
-              "id": "stalenessAndCulling",
+              "id": "stalenessAndDeletion",
               "appId": "inventory",
-              "title": "Staleness and Culling",
-              "href": "/insights/inventory/staleness-and-culling",
+              "title": "Staleness and Deletion",
+              "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Culling",
+              "description": "Inventory Host Staleness and Deletion",
               "permissions": [
                 {
                   "method": "featureFlag",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -132,12 +132,12 @@
               ]
             },
             {
-              "id": "stalenessAndCulling",
+              "id": "stalenessAndDeletion",
               "appId": "inventory",
-              "title": "Staleness and Culling",
-              "href": "/insights/inventory/staleness-and-culling",
+              "title": "Staleness and Deletion",
+              "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Culling",
+              "description": "Inventory Host Staleness and Deletion",
               "permissions": [
                 {
                   "method": "featureFlag",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -132,12 +132,12 @@
               ]
             },
             {
-              "id": "stalenessAndCulling",
+              "id": "stalenessAndDeletion",
               "appId": "inventory",
-              "title": "Staleness and Culling",
-              "href": "/insights/inventory/staleness-and-culling",
+              "title": "Staleness and Deletion",
+              "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Culling",
+              "description": "Inventory Host Staleness and Deletion",
               "permissions": [
                 {
                   "method": "featureFlag",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -132,12 +132,12 @@
               ]
             },
             {
-              "id": "stalenessAndCulling",
+              "id": "stalenessAndDeletion",
               "appId": "inventory",
-              "title": "Staleness and Culling",
-              "href": "/insights/inventory/staleness-and-culling",
+              "title": "Staleness and Deletion",
+              "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Culling",
+              "description": "Inventory Host Staleness and Deletion",
               "permissions": [
                 {
                   "method": "featureFlag",


### PR DESCRIPTION
This nav item is still protected by the feature flag, but as per UX directions, The page will now be named 'Staleness and Deletion' as opposed to 'Staleness and Culling'.