### PR TITLE
Add Business Services bundle to prod-stable

### DIFF
--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -695,6 +695,25 @@
             }
         ]
     },
+    "hybridCommittedSpend": {
+        "manifestLocation": "/apps/hybrid-committed-spend/fed-mods.json",
+        "config": {
+            "ssoScopes": [
+                "api.billing.hcs_reports"
+            ]
+        },
+        "modules": [
+            {
+                "id": "hybrid-committed-spend",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/business-services/hybrid-committed-spend"
+                    }
+                ]
+            }
+        ]
+    },
     "imageBuilder": {
         "manifestLocation": "/apps/image-builder/fed-mods.json",
         "modules": [

--- a/static/stable/prod/navigation/business-services-navigation.json
+++ b/static/stable/prod/navigation/business-services-navigation.json
@@ -1,0 +1,29 @@
+
+{
+    "id": "business-services",
+    "title": "Business Services",
+    "navItems": [
+      {
+        "title": "Hybrid Committed Spend",
+        "expandable": true,
+        "filterable": false,
+        "id": "hybridCommittedSpend",
+        "description": "Compare the difference between the commitment and actual Red Hat spending.",
+        "routes": [
+          {
+            "id": "overview",
+            "appId": "hybridCommittedSpend",
+            "title": "Overview",
+            "href": "/business-services/hybrid-committed-spend",
+            "icon": "PlaceholderIcon"
+          },
+          {
+            "id": "details",
+            "appId": "hybridCommittedSpend",
+            "title": "Details",
+            "href": "/business-services/hybrid-committed-spend/details"
+          }
+        ]
+      }
+    ]
+  }

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -257,7 +257,7 @@
         "isGroup": true,
         "title": "Advanced Cluster Security",
         "links": [
-          "application-services.clusterOverview"          
+          "application-services.clusterOverview"
         ]
       },
       {
@@ -400,6 +400,17 @@
     "links": [
       "openshift.costManagement",
       "rhel.ros"
+    ]
+  },
+  {
+    "id": "spendManagement",
+    "icon": "CreditCardIcon",
+    "title": "Spend Management",
+    "description": "Control costs and monitor committed spend.",
+    "links": [
+      "openshift.costManagement",
+      "rhel.ros",
+      "business-services.hybridCommittedSpend"
     ]
   },
   {


### PR DESCRIPTION
The HCS UI has already been pushed through the container pipeline, so it's ready in prod-stable. We just need to push the "Business Services" bundle to make the it visible.

https://issues.redhat.com/browse/HCS-243