### PR TITLE
Restoring OpenShiftIcon to Overview in OCM navigation

### DIFF
--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -7,6 +7,7 @@
             "appId": "openshift",
             "href": "/openshift/overview",
             "title": "Overview",
+            "icon": "OpenShiftIcon",
             "filterable": false,
             "product": "Red Hat OpenShift Cluster Manager",
             "description": "Red Hat OpenShift cluster product information"


### PR DESCRIPTION
In a previous PR (https://github.com/RedHatInsights/chrome-service-backend/pull/296) the icon was removed.
We do want to continue using it for overview.