### PR TITLE
Hide integrations nav behind feature flag

### DIFF
--- a/static/beta/prod/navigation/settings-navigation.json
+++ b/static/beta/prod/navigation/settings-navigation.json
@@ -58,6 +58,12 @@
                 "operational workflow",
                 "google spaces",
                 "ms teams"
+            ],
+            "permissions": [
+                {
+                    "method": "featureFlag",
+                    "args": ["platform.sources.integrations", false]
+                }
             ]
         },
         {

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -58,6 +58,12 @@
                 "operational workflow",
                 "google spaces",
                 "ms teams"
+            ],
+            "permissions": [
+                {
+                    "method": "featureFlag",
+                    "args": ["platform.sources.integrations", false]
+                }
             ]
         },
         {


### PR DESCRIPTION
### Description

Since we are migrating integrations over to sources we should hide the integrations endpoint in navigation if the flag is enabled. This PR adds this condition to stage stable and prod preview.