### PR TITLE
OCPADVISOR-121: workloads navigation in stage

### DIFF
--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -77,6 +77,19 @@
                             "title": "Clusters",
                             "href": "/openshift/insights/advisor/clusters",
                             "product": "Red Hat OpenShift Cluster Manager"
+                        },
+                        {
+                            "id": "workloads",
+                            "appId": "ocpAdvisor",
+                            "title": "Workloads",
+                            "href": "/openshift/insights/advisor/workloads",
+                            "product": "Red Hat OpenShift Cluster Manager",
+                            "permissions": [
+                                {
+                                  "method": "featureFlag",
+                                  "args": ["ocp-advisor-ui-workloads", true]
+                                }
+                              ]
                         }
                     ]
                 },


### PR DESCRIPTION
EPIC link: https://issues.redhat.com/browse/OCPADVISOR-121

Add workloads navigation to the stage config, it should be hidden behind the feature flag "ocp-advisor-ui-workloads"