### PR TITLE
add trusted content to stage-beta

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -879,6 +879,9 @@
                 "module": "./RootApp",
                 "routes": [
                     {
+                        "pathname": "/application-services/trusted-content"
+                    },
+                    {
                         "pathname": "/application-services/databases"
                     }
                 ]


### PR DESCRIPTION
Trusted content should be working in stage-preview, but it's currently getting a 404 page