### PR TITLE
fix(RHCLOUD-28994): Reorg Inventory groups bundle

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -203,6 +203,11 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
+      },
+      {
+        "title": "Inventory Groups",
+        "href": "/insights/inventory/groups",
+        "icon": "InsightsIcon"
       }
     ]
   },
@@ -305,11 +310,6 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "title": "Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
-          },
           "rhel.advisories",
           {
             "href": "/insights/advisor/recommendations",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -204,6 +204,11 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
+      },
+      {
+        "title": "Inventory Groups",
+        "href": "/insights/inventory/groups",
+        "icon": "InsightsIcon"
       }      
     ]
   },
@@ -306,11 +311,6 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "title": "Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
-          },
           "rhel.advisories",
           {
             "href": "/insights/advisor/recommendations",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -205,6 +205,11 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
+      },
+      {
+        "title": "Inventory Groups",
+        "href": "/insights/inventory/groups",
+        "icon": "InsightsIcon"
       }
     ]
   },
@@ -295,11 +300,6 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "title": "Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
-          },
           "rhel.advisories",
           {
             "href": "/insights/advisor/recommendations",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -204,6 +204,11 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
+      },
+      {
+        "title": "Inventory Groups",
+        "href": "/insights/inventory/groups",
+        "icon": "InsightsIcon"
       }
     ]
   },
@@ -306,11 +311,6 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "title": "Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
-          },
           "rhel.advisories",
           {
             "href": "/insights/advisor/recommendations",


### PR DESCRIPTION
In accordance with https://issues.redhat.com/browse/RHCLOUD-28994, this PR
 1. Slaps inventory groups in inventorys bundle
 Inventories>RHEL>Groups

2. Edge groups is removed from Security->RHEL