### PR TITLE
feat(RHINENG-2753): Staleness desc update & update to System Configur…

### DIFF
--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -138,7 +138,7 @@
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Deletion",
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [
                 {
                   "method": "featureFlag",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -454,7 +454,8 @@
           "settings.manageConfiguration",
           "rhel.activationKeys",
           "rhel.manifests",
-          "rhel.registerSystems"
+          "rhel.registerSystems",
+          "rhel.stalenessAndDeletion"
         ]
       },
       {

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -137,7 +137,7 @@
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Deletion",
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [
                 {
                   "method": "featureFlag",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -455,7 +455,8 @@
           "settings.manageConfiguration",
           "rhel.activationKeys",
           "rhel.manifests",
-          "rhel.registerSystems"
+          "rhel.registerSystems",
+          "rhel.stalenessAndDeletion"
         ]
       },
       {

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -137,7 +137,7 @@
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Deletion",
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [
                 {
                   "method": "featureFlag",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -444,7 +444,8 @@
           "settings.manageConfiguration",
           "rhel.activationKeys",
           "rhel.manifests",
-          "rhel.registerSystems"
+          "rhel.registerSystems",
+          "rhel.stalenessAndDeletion"
         ]
       },
       {

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -137,7 +137,7 @@
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
               "product": "Red Hat Insights",
-              "description": "Inventory Host Staleness and Deletion",
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [
                 {
                   "method": "featureFlag",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -455,7 +455,8 @@
           "settings.manageConfiguration",
           "rhel.activationKeys",
           "rhel.manifests",
-          "rhel.registerSystems"
+          "rhel.registerSystems",
+          "rhel.stalenessAndDeletion"
         ]
       },
       {


### PR DESCRIPTION
In accordance with https://issues.redhat.com/browse/RHINENG-2753, This PR updates the system configuration tab in the services menu to include staleness and deletion. 

The item im adding has a feature flag. when adding the component to the services.json  file via "rhel.stalenessAndDeletion" , is it also grabbing the permissions? Just want to be sure, I dont seen any examples of feature flags on any of the services.json files. 
