### PR TITLE
fix(RHCLOUD-28994): Icon for staleness & Inventory Groups seciton change

### DIFF
--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -137,6 +137,7 @@
               "appId": "inventory",
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
+              "icon": "InsightsIcon",
               "product": "Red Hat Insights",
               "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -180,7 +180,12 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.subscriptionsInventory",
-          "rhel.inventory"
+          "rhel.inventory",
+          {
+            "title": "Inventory Groups",
+            "href": "/insights/inventory/groups",
+            "icon": "InsightsIcon"
+          }
         ]
       },
       {
@@ -203,11 +208,6 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
-      },
-      {
-        "title": "Inventory Groups",
-        "href": "/insights/inventory/groups",
-        "icon": "InsightsIcon"
       }
     ]
   },

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -136,6 +136,7 @@
               "appId": "inventory",
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
+              "icon": "InsightsIcon",
               "product": "Red Hat Insights",
               "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -181,7 +181,12 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.subscriptionsInventory",
-          "rhel.inventory"
+          "rhel.inventory",
+          {
+            "title": "Inventory Groups",
+            "href": "/insights/inventory/groups",
+            "icon": "InsightsIcon"
+          }
         ]
       },
       {
@@ -204,12 +209,7 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
-      },
-      {
-        "title": "Inventory Groups",
-        "href": "/insights/inventory/groups",
-        "icon": "InsightsIcon"
-      }      
+      }  
     ]
   },
   {

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -136,6 +136,7 @@
               "appId": "inventory",
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
+              "icon": "InsightsIcon",
               "product": "Red Hat Insights",
               "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -182,7 +182,12 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.subscriptionsInventory",
-          "rhel.inventory"
+          "rhel.inventory",
+          {
+            "title": "Inventory Groups",
+            "href": "/insights/inventory/groups",
+            "icon": "InsightsIcon"
+          }
         ]
       },
       {
@@ -205,11 +210,6 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
-      },
-      {
-        "title": "Inventory Groups",
-        "href": "/insights/inventory/groups",
-        "icon": "InsightsIcon"
       }
     ]
   },

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -136,6 +136,7 @@
               "appId": "inventory",
               "title": "Staleness and Deletion",
               "href": "/insights/inventory/staleness-and-deletion",
+              "icon": "InsightsIcon",
               "product": "Red Hat Insights",
               "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
               "permissions": [

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -181,7 +181,12 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.subscriptionsInventory",
-          "rhel.inventory"
+          "rhel.inventory",
+        {
+          "title": "Inventory Groups",
+          "href": "/insights/inventory/groups",
+          "icon": "InsightsIcon"
+        }
         ]
       },
       {
@@ -204,11 +209,6 @@
         "links": [
           "subscriptions.subscriptionsInventory"
         ]
-      },
-      {
-        "title": "Inventory Groups",
-        "href": "/insights/inventory/groups",
-        "icon": "InsightsIcon"
       }
     ]
   },


### PR DESCRIPTION
This adds the Icon to staleness item and moves Inventory Groups under RHEL items as opposed to on top of it. 