### PR TITLE
Uses camel case instead of hyphens for virtual-assistant

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1080,7 +1080,7 @@
             }
         ]
     },
-    "virtual-assistant": {
+    "virtualAssistant": {
         "manifestLocation": "/apps/virtual-assistant/fed-mods.json",
         "modules": []
     }


### PR DESCRIPTION
Looks like the hyphen-case is converted to camelCase and then is impossible to load the components.

![image](https://github.com/RedHatInsights/chrome-service-backend/assets/3845764/b7ba0094-553a-4714-8867-9a54ae5a31b7)
