### PR TITLE
services.json: rename Ansible Hub -> Automation Hub

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -33,7 +33,7 @@
         "title": "Ansible",
         "links": [
           {
-            "title": "Ansible Hub",
+            "title": "Automation Hub",
             "href": "/ansible/automation-hub/",
             "icon": "AnsibleIcon"
           },

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -33,7 +33,7 @@
         "title": "Ansible",
         "links": [
           {
-            "title": "Ansible Hub",
+            "title": "Automation Hub",
             "href": "/ansible/automation-hub/",
             "icon": "AnsibleIcon"
           },

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -34,7 +34,7 @@
         "title": "Ansible",
         "links": [
           {
-            "title": "Ansible Hub",
+            "title": "Automation Hub",
             "href": "/ansible/automation-hub/",
             "icon": "AnsibleIcon"
           },

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -33,7 +33,7 @@
         "title": "Ansible",
         "links": [
           {
-            "title": "Ansible Hub",
+            "title": "Automation Hub",
             "href": "/ansible/automation-hub/",
             "icon": "AnsibleIcon"
           },


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/RedHatInsights/chrome-service-backend/pull/301

There is no such thing as an Ansible Hub, the right name is Automation Hub :).