### PR TITLE
Config for Cost Management microfrontend

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -281,6 +281,20 @@
             }
         ]
     },
+    "costManagementMfe": {
+        "manifestLocation": "/apps/cost-management-mfe/fed-mods.json",
+        "modules": [
+            {
+                "id": "cost-management-mfe",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/staging/cost-management"
+                    }
+                ]
+            }
+        ]
+    },
     "dashboard": {
         "manifestLocation": "/apps/dashboard/fed-mods.json",
         "isFedramp": true,
@@ -774,7 +788,7 @@
         "manifestLocation": "/apps/hac-core/fed-mods.json",
         "config": {
             "ssoScopes": [
-               "profile_level.name_and_dev_terms" 
+               "profile_level.name_and_dev_terms"
             ]
           },
         "modules": [

--- a/static/beta/stage/navigation/staging-navigation.json
+++ b/static/beta/stage/navigation/staging-navigation.json
@@ -7,6 +7,72 @@
             "title": "Starter App",
             "appId": "frontend-starter-app",
             "href": "/staging/starter"
+        },
+        {
+            "title": "Cost Management MFE",
+            "expandable": true,
+            "filterable": false,
+            "id": "costManagementMfe",
+            "description": "Cost Management Microfrontend with Module Federation",
+            "routes": [
+                {
+                    "title": "ROS",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "id": "optimizationsBadge",
+                            "appId": "costManagementMfe",
+                            "title": "Optimizations badge",
+                            "href": "/staging/cost-management/ros/optimizations/badge",
+                            "icon": "OpenShiftIcon"
+                        },
+                        {
+                            "id": "optimizationsLink",
+                            "appId": "costManagementMfe",
+                            "title": "Optimizations link",
+                            "href": "/staging/cost-management/ros/optimizations/link",
+                            "icon": "OpenShiftIcon"
+                        },
+                        {
+                            "id": "optimizationsSummary",
+                            "appId": "costManagementMfe",
+                            "title": "Optimizations summary",
+                            "href": "/staging/cost-management/ros/optimizations/summary",
+                            "icon": "OpenShiftIcon"
+                        },
+                        {
+                            "id": "optimizationsTable",
+                            "appId": "costManagementMfe",
+                            "title": "Optimizations table",
+                            "href": "/staging/cost-management/ros/optimizations/table"
+                        },
+                        {
+                            "id": "optimizationsDetails",
+                            "appId": "costManagementMfe",
+                            "title": "Optimizations details",
+                            "href": "/staging/cost-management/ros/optimizations/details"
+                        },
+                        {
+                            "id": "optimizationsBreakdown",
+                            "appId": "costManagementMfe",
+                            "title": "Optimizations breakdown",
+                            "href": "/staging/cost-management/ros/optimizations/breakdown"
+                        }
+                    ]
+                },
+                {
+                    "title": "OCM",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "id": "ocmOverview",
+                            "appId": "costManagementMfe",
+                            "title": "Overview Card",
+                            "href": "/staging/cost-management/ocm/overview"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Created a new container build pipline for a Cost Management microfrontend.

We want to move ROS and OCM features out of the Cost Management repo and deliver functionality as Federated Modules. This will unblock Cost Management (allowing us to push to prod) while waiting for the ROS QE team to verify bug fixes, new features, etc. and vise versa.

Note: Spoke to Martin about using the staging bundle to test / demo our Federated Modules.
Already created the container build pipeline, and will request Akamai Routing Rules next.