### PR TITLE
chore(RHINENG-2822): Remove hbi.ui.inventory-groups feature flag

### DIFF
--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -33,13 +33,7 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Inventory groups",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["hbi.ui.inventory-groups", true]
-            }
-          ]
+          "description": "Inventory groups"          
         },
         {
           "id": "imageBuilder",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -32,13 +32,7 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Inventory groups",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["hbi.ui.inventory-groups", true]
-            }
-          ]
+          "description": "Inventory groups"
         },
         {
           "id": "imageBuilder",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -32,13 +32,7 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Inventory groups",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["hbi.ui.inventory-groups", true]
-            }
-          ]
+          "description": "Inventory groups"
         },
         {
           "id": "imageBuilder",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -32,13 +32,7 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Inventory groups",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["hbi.ui.inventory-groups", true]
-            }
-          ]
+          "description": "Inventory groups"          
         },
         {
           "id": "imageBuilder",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-2822.

This removes all occurrences of the "hbi.ui.inventory-groups" feature flag. The flag is no longer planned to switch, and the feature is considered stable in production.