### PR TITLE
Revert "Disable service accounts on prod stable"

### DIFF
--- a/static/stable/prod/navigation/iam-navigation.json
+++ b/static/stable/prod/navigation/iam-navigation.json
@@ -79,6 +79,18 @@
       ]
     },
     {
+      "id": "serviceAccounts",
+      "title": "Service Accounts",
+      "appId": "serviceAccounts",
+      "href": "/iam/service-accounts",
+      "permissions": [
+        {
+          "method": "featureFlag",
+          "args": ["platform.iam.service-accounts", true]
+        }
+      ]
+    },
+    {
       "id": "learningResources",
       "appId": "learningResources",
       "title": "Learning Resources",


### PR DESCRIPTION
Reverts RedHatInsights/chrome-service-backend#373 turns out we still can have the nav in prod stable, just not in RBAC