### PR TITLE
fix(RHINENG-2398): Add descriptions to Inventory Groups

### DIFF
--- a/static/beta/itless/services/services.json
+++ b/static/beta/itless/services/services.json
@@ -28,7 +28,8 @@
           {
             "title": "Inventory Groups",
             "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
+            "icon": "InsightsIcon",
+            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
           }
         ]
       },

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -184,7 +184,8 @@
           {
             "title": "Inventory Groups",
             "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
+            "icon": "InsightsIcon",
+            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
           }
         ]
       },

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -185,7 +185,8 @@
           {
             "title": "Inventory Groups",
             "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
+            "icon": "InsightsIcon",
+            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
           }
         ]
       },

--- a/static/stable/itless/services/services.json
+++ b/static/stable/itless/services/services.json
@@ -28,7 +28,8 @@
           {
             "title": "Inventory Groups",
             "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
+            "icon": "InsightsIcon",
+            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
           }
         ]
       },

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -186,7 +186,8 @@
           {
             "title": "Inventory Groups",
             "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon"
+            "icon": "InsightsIcon",
+            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
           }
         ]
       },

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -185,7 +185,8 @@
         {
           "title": "Inventory Groups",
           "href": "/insights/inventory/groups",
-          "icon": "InsightsIcon"
+          "icon": "InsightsIcon",
+          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
         }
         ]
       },


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-2398.

This adds missing descriptions for Inventory Groups entry under "Inventories" section (Services dropdown).

![Screenshot 2024-01-09 at 22 28 09](https://github.com/RedHatInsights/chrome-service-backend/assets/31385370/d7725673-a7ff-45a7-be49-5732487d3ffc)
