### PR TITLE
[RHCLOUD-30109] Update api server to handle batch last-visited updates

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 		subrouter.Use(m.InjectUser)
 		subrouter.Get("/hello-world", HelloWorld)
 		subrouter.Route("/last-visited", routes.MakeLastVisitedRoutes)
+		subrouter.Route("/last-visited-batch", routes.MakeLastVisitedBatchRoutes)
 		subrouter.Route("/favorite-pages", routes.MakeFavoritePagesRoutes)
 		subrouter.Route("/self-report", routes.MakeSelfReportRoutes)
 		subrouter.Route("/user", routes.MakeUserIdentityRoutes)

--- a/main.go
+++ b/main.go
@@ -58,7 +58,6 @@ func main() {
 		subrouter.Use(m.InjectUser)
 		subrouter.Get("/hello-world", HelloWorld)
 		subrouter.Route("/last-visited", routes.MakeLastVisitedRoutes)
-		subrouter.Route("/last-visited-batch", routes.MakeLastVisitedBatchRoutes)
 		subrouter.Route("/favorite-pages", routes.MakeFavoritePagesRoutes)
 		subrouter.Route("/self-report", routes.MakeSelfReportRoutes)
 		subrouter.Route("/user", routes.MakeUserIdentityRoutes)

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -19,15 +19,15 @@ CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 # Need to make a dummy results file to make tests pass
-mkdir -p $WORKSPACE
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+mkdir -p "WORKSPACE"
+cat << EOF > "$WORKSPACE/artifacts/junit-dummy.xml"
 <testsuite tests="1">
     <testcase classname="dummy" name="dummytest"/>
 </testsuite>
 EOF
 
 # Build and publish container image
-source $CICD_ROOT/build.sh
+source "$CICD_ROOT/build.sh"
 
 ## Roll out ephemeral env
-source $CICD_ROOT/deploy_ephemeral_env.sh
+source "$CICD_ROOT/deploy_ephemeral_env.sh"

--- a/rest/models/LastVisitedPage.go
+++ b/rest/models/LastVisitedPage.go
@@ -7,3 +7,25 @@ type LastVisitedPage struct {
 	Title          string `json:"title"`
 	UserIdentityID uint   `json:"userIdentityId"`
 }
+
+type LastVisitedPages struct {
+	Pages []LastVisitedPage `json:"pages"`
+}
+
+type LastVisitedPageResponse struct {
+	Bundle   string `json:"bundle"`
+	Pathname string `json:"pathname"`
+	Title    string `json:"title"`
+}
+
+func CastLastVisitedResponse(pages []LastVisitedPage) []LastVisitedPageResponse {
+	var casted []LastVisitedPageResponse
+	for _, v := range pages {
+		casted = append(casted, LastVisitedPageResponse{
+			Bundle:   v.Bundle,
+			Pathname: v.Pathname,
+			Title:    v.Title,
+		})
+	}
+	return casted
+}

--- a/rest/models/UserIdentity.go
+++ b/rest/models/UserIdentity.go
@@ -17,3 +17,15 @@ type UserIdentity struct {
 	SelfReport       SelfReport        `json:"selfReport"`
 	VisitedBundles   datatypes.JSON    `json:"visitedBundles,omitempty" gorm:"type: JSONB"`
 }
+
+type UserIdentityResponse struct {
+	BaseModel
+	AccountId        string                    `json:"accountId,omitempty"`
+	FirstLogin       bool                      `json:"firstLogin"`
+	DayOne           bool                      `json:"dayOne"`
+	LastLogin        time.Time                 `json:"lastLogin"`
+	LastVisitedPages []LastVisitedPageResponse `json:"lastVisitedPages"`
+	FavoritePages    []FavoritePage            `json:"favoritePages"`
+	SelfReport       SelfReport                `json:"selfReport"`
+	VisitedBundles   datatypes.JSON            `json:"visitedBundles,omitempty" gorm:"type: JSONB"`
+}

--- a/rest/routes/identity.go
+++ b/rest/routes/identity.go
@@ -2,12 +2,11 @@ package routes
 
 import (
 	"encoding/json"
-	"net/http"
-
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
 	"github.com/RedHatInsights/chrome-service-backend/rest/service"
 	"github.com/RedHatInsights/chrome-service-backend/rest/util"
 	"github.com/go-chi/chi/v5"
+	"net/http"
 )
 
 type AddVisitedBundlePayload struct {
@@ -22,8 +21,20 @@ func GetUserIdentity(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 
-	resp := util.EntityResponse[models.UserIdentity]{
-		Data: updatedUser,
+	responsePages := models.CastLastVisitedResponse(updatedUser.LastVisitedPages)
+	response := models.UserIdentityResponse{
+		AccountId:        updatedUser.AccountId,
+		FirstLogin:       updatedUser.FirstLogin,
+		DayOne:           updatedUser.DayOne,
+		LastLogin:        updatedUser.LastLogin,
+		LastVisitedPages: responsePages,
+		FavoritePages:    updatedUser.FavoritePages,
+		SelfReport:       updatedUser.SelfReport,
+		VisitedBundles:   updatedUser.VisitedBundles,
+	}
+
+	resp := util.EntityResponse[models.UserIdentityResponse]{
+		Data: response,
 	}
 
 	json.NewEncoder(w).Encode(resp)

--- a/rest/routes/lastVisited.go
+++ b/rest/routes/lastVisited.go
@@ -2,23 +2,20 @@ package routes
 
 import (
 	"encoding/json"
-	"net/http"
-
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
 	"github.com/RedHatInsights/chrome-service-backend/rest/service"
 	"github.com/RedHatInsights/chrome-service-backend/rest/util"
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
+	"net/http"
 )
 
 func StoreLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 	user := r.Context().Value(util.USER_CTX_KEY).(models.UserIdentity)
 	userId := user.ID
-	var recentPages []models.LastVisitedPage
+	var recentPages models.LastVisitedPages
+
 	err := json.NewDecoder(r.Body).Decode(&recentPages)
-	for _, v := range recentPages {
-		v.UserIdentityID = userId
-	}
 
 	if err != nil {
 		errString := "Invalid last visited pages request payload."
@@ -28,7 +25,7 @@ func StoreLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = service.HandlePostLastVisitedPages(recentPages, userId)
+	err = service.HandlePostLastVisitedPages(recentPages.Pages, userId)
 	if err != nil {
 		panic(err)
 	}
@@ -38,8 +35,8 @@ func StoreLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 
-	resp := util.ListResponse[models.LastVisitedPage]{
-		Data: pages,
+	resp := util.ListResponse[models.LastVisitedPageResponse]{
+		Data: models.CastLastVisitedResponse(pages),
 		Meta: util.ListMeta{
 			Count: len(pages),
 			Total: len(pages),
@@ -57,8 +54,8 @@ func GetLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		panic(err)
 	}
-	resp := util.ListResponse[models.LastVisitedPage]{
-		Data: pages,
+	resp := util.ListResponse[models.LastVisitedPageResponse]{
+		Data: models.CastLastVisitedResponse(pages),
 		Meta: util.ListMeta{
 			Count: len(pages),
 			Total: len(pages),

--- a/rest/routes/lastVisited.go
+++ b/rest/routes/lastVisited.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func BatchLastVisitedPages(w http.ResponseWriter, r *http.Request) {
+func StoreLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 	user := r.Context().Value(util.USER_CTX_KEY).(models.UserIdentity)
 	userId := user.ID
 	var recentPages []models.LastVisitedPage
@@ -28,46 +28,10 @@ func BatchLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = service.HandlePostBatchLastVisitedPages(recentPages, userId)
+	err = service.HandlePostLastVisitedPages(recentPages, userId)
 	if err != nil {
 		panic(err)
 	}
-	pages, err := service.GetUsersLastVisitedPages(userId)
-
-	if err != nil {
-		panic(err)
-	}
-
-	resp := util.ListResponse[models.LastVisitedPage]{
-		Data: pages,
-		Meta: util.ListMeta{
-			Count: len(pages),
-			Total: len(pages),
-		},
-	}
-	json.NewEncoder(w).Encode(resp)
-}
-
-func StoreLastVisitedPage(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value(util.USER_CTX_KEY).(models.UserIdentity)
-	userId := user.ID
-	var currentPage models.LastVisitedPage
-	err := json.NewDecoder(r.Body).Decode(&currentPage)
-	currentPage.UserIdentityID = userId
-
-	if err != nil {
-		errString := "Invalid last visited pages request payload."
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(errString))
-		logrus.Errorf("unable to request body for last visited pages, %s", err.Error())
-		return
-	}
-
-	err = service.HandlePostLastVisitedPages(userId, currentPage)
-	if err != nil {
-		panic(err)
-	}
-
 	pages, err := service.GetUsersLastVisitedPages(userId)
 
 	if err != nil {
@@ -104,10 +68,6 @@ func GetLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 }
 
 func MakeLastVisitedRoutes(sub chi.Router) {
-	sub.Post("/", StoreLastVisitedPage)
+	sub.Post("/", StoreLastVisitedPages)
 	sub.Get("/", GetLastVisitedPages)
-}
-
-func MakeLastVisitedBatchRoutes(sub chi.Router) {
-	sub.Post("/", BatchLastVisitedPages)
 }

--- a/rest/routes/lastVisited.go
+++ b/rest/routes/lastVisited.go
@@ -11,7 +11,42 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TODO: This needs a queue setup
+func BatchLastVisitedPages(w http.ResponseWriter, r *http.Request) {
+	user := r.Context().Value(util.USER_CTX_KEY).(models.UserIdentity)
+	userId := user.ID
+	var recentPages []models.LastVisitedPage
+	err := json.NewDecoder(r.Body).Decode(&recentPages)
+	for _, v := range recentPages {
+		v.UserIdentityID = userId
+	}
+
+	if err != nil {
+		errString := "Invalid last visited pages request payload."
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(errString))
+		logrus.Errorf("unable to request body for last visited pages, %s", err.Error())
+		return
+	}
+
+	err = service.HandlePostBatchLastVisitedPages(recentPages, userId)
+	if err != nil {
+		panic(err)
+	}
+	pages, err := service.GetUsersLastVisitedPages(userId)
+
+	if err != nil {
+		panic(err)
+	}
+
+	resp := util.ListResponse[models.LastVisitedPage]{
+		Data: pages,
+		Meta: util.ListMeta{
+			Count: len(pages),
+			Total: len(pages),
+		},
+	}
+	json.NewEncoder(w).Encode(resp)
+}
 
 func StoreLastVisitedPage(w http.ResponseWriter, r *http.Request) {
 	user := r.Context().Value(util.USER_CTX_KEY).(models.UserIdentity)
@@ -71,4 +106,8 @@ func GetLastVisitedPages(w http.ResponseWriter, r *http.Request) {
 func MakeLastVisitedRoutes(sub chi.Router) {
 	sub.Post("/", StoreLastVisitedPage)
 	sub.Get("/", GetLastVisitedPages)
+}
+
+func MakeLastVisitedBatchRoutes(sub chi.Router) {
+	sub.Post("/", BatchLastVisitedPages)
 }

--- a/rest/service/lastVisitedService.go
+++ b/rest/service/lastVisitedService.go
@@ -3,8 +3,6 @@ package service
 import (
 	"github.com/RedHatInsights/chrome-service-backend/rest/database"
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
-	"github.com/RedHatInsights/chrome-service-backend/rest/util"
-	"gorm.io/gorm"
 )
 
 // GetUsersLastVisitedPages returns all users last visited pages records
@@ -26,9 +24,9 @@ func CheckExistingPage(pages []models.LastVisitedPage, currentPage models.LastVi
 	return pageExists
 }
 
-// HandlePostBatchLastVisitedPages inserts the 10 most recent pages from chrome. Once the 10 are added,
+// HandlePostLastVisitedPages inserts the most recent pages from chrome. Once they are added,
 // all older entries are removed from the table.
-func HandlePostBatchLastVisitedPages(recentPages []models.LastVisitedPage, userId uint) error {
+func HandlePostLastVisitedPages(recentPages []models.LastVisitedPage, accountId uint) error {
 	var ids []uint
 	for _, v := range recentPages {
 		if err := database.DB.Create(&v).Error; err != nil {
@@ -36,60 +34,13 @@ func HandlePostBatchLastVisitedPages(recentPages []models.LastVisitedPage, userI
 			// corrected by a subsequent successful call
 			return err
 		}
-		// ids are given to the entry from Gorm AFTER they are successfully inserted
+		// Unique ids are given to the entry from Gorm AFTER they are successfully inserted
 		ids = append(ids, v.ID)
 	}
 	// Since we have all the IDs of the newly added pages, we can remove all other pages
-	err := database.DB.Where("user_identity_id = ?", userId).Where("id NOT IN ?", ids).Delete(&models.LastVisitedPage{}).Error
+	err := database.DB.Where("user_identity_id = ?", accountId).Where("id NOT IN ?", ids).Delete(&models.LastVisitedPage{}).Error
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-func HandlePostLastVisitedPages(accountId uint, currentPage models.LastVisitedPage) error {
-	// Try the entire thing in one transaction
-	return database.DB.Transaction(func(tx *gorm.DB) error {
-		var pages []models.LastVisitedPage
-		// Lock this row until updated
-		err := database.DB.Order("updated_at desc").Where("user_identity_id = ?", accountId).Find(&pages).Error
-		if err != nil {
-			tx.Rollback()
-			return err
-		}
-		pageExists := CheckExistingPage(pages, currentPage)
-		if pageExists {
-			if err := tx.Model(&models.LastVisitedPage{}).Where("pathname = ?", currentPage.Pathname).Updates(models.LastVisitedPage{
-				Title:    currentPage.Title, // title of a page can change
-				Pathname: currentPage.Pathname,
-				Bundle:   currentPage.Bundle,
-			}).Error; err != nil {
-				tx.Rollback()
-				return err
-			}
-			return nil
-		} else {
-			if len(pages) == util.LAST_VISITED_MAX {
-				obsoletePage := pages[len(pages)-1]
-				// hard remove from DB. We don't want to keep insanely large history of pages
-				if err := tx.Unscoped().Delete(&obsoletePage).Error; err != nil {
-					tx.Rollback()
-					return err
-				}
-			} else if len(pages) > util.LAST_VISITED_MAX {
-				// if account gets in bad state, remove all until only max allowed remain
-				for i := util.LAST_VISITED_MAX - 1; i < len(pages); i++ {
-					if err := tx.Unscoped().Delete(pages[i]).Error; err != nil {
-						tx.Rollback()
-						return err
-					}
-				}
-			}
-			if err := database.DB.Create(&currentPage).Error; err != nil {
-				tx.Rollback()
-				return err
-			}
-			return nil
-		}
-	})
 }

--- a/rest/service/lastVisitedService.go
+++ b/rest/service/lastVisitedService.go
@@ -3,6 +3,7 @@ package service
 import (
 	"github.com/RedHatInsights/chrome-service-backend/rest/database"
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
+	"github.com/sirupsen/logrus"
 )
 
 // GetUsersLastVisitedPages returns all users last visited pages records
@@ -12,23 +13,12 @@ func GetUsersLastVisitedPages(accountId uint) ([]models.LastVisitedPage, error) 
 	return pages, err
 }
 
-// CheckExistingPage determines if the currently visited page is already in the visited pages array
-func CheckExistingPage(pages []models.LastVisitedPage, currentPage models.LastVisitedPage) bool {
-	pageExists := false
-	for _, page := range pages {
-		if page.Pathname == currentPage.Pathname {
-			pageExists = true
-			break
-		}
-	}
-	return pageExists
-}
-
 // HandlePostLastVisitedPages inserts the most recent pages from chrome. Once they are added,
 // all older entries are removed from the table.
 func HandlePostLastVisitedPages(recentPages []models.LastVisitedPage, accountId uint) error {
 	var ids []uint
 	for _, v := range recentPages {
+		v.UserIdentityID = accountId
 		if err := database.DB.Create(&v).Error; err != nil {
 			// If we encounter an error, we want to bail out of the deletion as well. Extra pages will be
 			// corrected by a subsequent successful call
@@ -37,8 +27,10 @@ func HandlePostLastVisitedPages(recentPages []models.LastVisitedPage, accountId 
 		// Unique ids are given to the entry from Gorm AFTER they are successfully inserted
 		ids = append(ids, v.ID)
 	}
+	logrus.Debugf("%+v\n", recentPages)
+	logrus.Debugf("%+v\n", ids)
 	// Since we have all the IDs of the newly added pages, we can remove all other pages
-	err := database.DB.Where("user_identity_id = ?", accountId).Where("id NOT IN ?", ids).Delete(&models.LastVisitedPage{}).Error
+	err := database.DB.Unscoped().Where("user_identity_id = ?", accountId).Where("id NOT IN ?", ids).Delete(&models.LastVisitedPage{}).Error
 	if err != nil {
 		return err
 	}

--- a/rest/service/lastVisitedService.go
+++ b/rest/service/lastVisitedService.go
@@ -5,17 +5,16 @@ import (
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
 	"github.com/RedHatInsights/chrome-service-backend/rest/util"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
-// Get all users last visited pages records
+// GetUsersLastVisitedPages returns all users last visited pages records
 func GetUsersLastVisitedPages(accountId uint) ([]models.LastVisitedPage, error) {
 	var pages []models.LastVisitedPage
 	err := database.DB.Order("updated_at desc").Where("user_identity_id = ?", accountId).Find(&pages).Error
 	return pages, err
 }
 
-// Check if the currently visited page is already in the visited pages array
+// CheckExistingPage determines if the currently visited page is already in the visited pages array
 func CheckExistingPage(pages []models.LastVisitedPage, currentPage models.LastVisitedPage) bool {
 	pageExists := false
 	for _, page := range pages {
@@ -27,13 +26,35 @@ func CheckExistingPage(pages []models.LastVisitedPage, currentPage models.LastVi
 	return pageExists
 }
 
+// HandlePostBatchLastVisitedPages inserts the 10 most recent pages from chrome. Once the 10 are added,
+// all older entries are removed from the table.
+func HandlePostBatchLastVisitedPages(recentPages []models.LastVisitedPage, userId uint) error {
+	var ids []uint
+	for _, v := range recentPages {
+		if err := database.DB.Create(&v).Error; err != nil {
+			// If we encounter an error, we want to bail out of the deletion as well. Extra pages will be
+			// corrected by a subsequent successful call
+			return err
+		}
+		// ids are given to the entry from Gorm AFTER they are successfully inserted
+		ids = append(ids, v.ID)
+	}
+	// Since we have all the IDs of the newly added pages, we can remove all other pages
+	err := database.DB.Where("user_identity_id = ?", userId).Where("id NOT IN ?", ids).Delete(&models.LastVisitedPage{}).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func HandlePostLastVisitedPages(accountId uint, currentPage models.LastVisitedPage) error {
 	// Try the entire thing in one transaction
 	return database.DB.Transaction(func(tx *gorm.DB) error {
 		var pages []models.LastVisitedPage
 		// Lock this row until updated
-		err := database.DB.Clauses(clause.Locking{Strength: "UPDATE"}).Order("updated_at desc").Where("user_identity_id = ?", accountId).Find(&pages).Error
+		err := database.DB.Order("updated_at desc").Where("user_identity_id = ?", accountId).Find(&pages).Error
 		if err != nil {
+			tx.Rollback()
 			return err
 		}
 		pageExists := CheckExistingPage(pages, currentPage)
@@ -43,6 +64,7 @@ func HandlePostLastVisitedPages(accountId uint, currentPage models.LastVisitedPa
 				Pathname: currentPage.Pathname,
 				Bundle:   currentPage.Bundle,
 			}).Error; err != nil {
+				tx.Rollback()
 				return err
 			}
 			return nil
@@ -51,17 +73,20 @@ func HandlePostLastVisitedPages(accountId uint, currentPage models.LastVisitedPa
 				obsoletePage := pages[len(pages)-1]
 				// hard remove from DB. We don't want to keep insanely large history of pages
 				if err := tx.Unscoped().Delete(&obsoletePage).Error; err != nil {
+					tx.Rollback()
 					return err
 				}
 			} else if len(pages) > util.LAST_VISITED_MAX {
 				// if account gets in bad state, remove all until only max allowed remain
 				for i := util.LAST_VISITED_MAX - 1; i < len(pages); i++ {
 					if err := tx.Unscoped().Delete(pages[i]).Error; err != nil {
+						tx.Rollback()
 						return err
 					}
 				}
 			}
 			if err := database.DB.Create(&currentPage).Error; err != nil {
+				tx.Rollback()
 				return err
 			}
 			return nil

--- a/rest/service/service_test.go
+++ b/rest/service/service_test.go
@@ -93,5 +93,10 @@ func TestDeadlock(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
+		db, _ := database.DB.DB()
+		openConnections := db.Stats().OpenConnections
+		if openConnections != 0 {
+			t.Errorf("Leaked %d database connections", openConnections)
+		}
 	})
 }


### PR DESCRIPTION
* POST `/last-visited` now updates from local storage and overwrites the previous data
* GET `/last-visited` filters the db metadata