### PR TITLE
chore: fix example endpoint path in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PGSQL_DATABASE=postgres
 3. To test the service, at the moment, you are able to hit the following endpoint:
 ```
 GET http://localhost:8000/health
-GET http://localhost:8000/api/chrome/v1/hello-world
+GET http://localhost:8000/api/chrome-service/v1/hello-world
 ```
 
 ### Headers


### PR DESCRIPTION
I was trying this out locally and noticed that the example hello-world endpoint is incorrect.