### PR TITLE
AAP-20059: Admin Dashboard: Usage telemetry. Add temporary Segment keys for development purposes

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1083,6 +1083,9 @@
                 "api.iam.access"
             ]
         },
+        "analytics": {
+            "APIKey": "18MX366WgwDiWsrMiai4iS3zKL0aW1rX"
+        },
         "modules": [
             {
                 "id": "ansible-wisdom-admin-dashboard",

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -1076,6 +1076,9 @@
               "api.iam.access"
           ]
       },
+      "analytics": {
+          "APIKey": "18MX366WgwDiWsrMiai4iS3zKL0aW1rX"
+      },
       "modules": [
           {
               "id": "ansible-wisdom-admin-dashboard",


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-20059

This PR adds a temporary Segment API Key to aid development of the referenced feature.

When things are working as expected I will switch over to a corporate Segment Key.