### PR TITLE
AAP-20139: Admin Dashboard: Add as 'Service' in HCC

### DIFF
--- a/static/beta/stage/navigation/ansible-navigation.json
+++ b/static/beta/stage/navigation/ansible-navigation.json
@@ -130,7 +130,6 @@
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",
                     "title": "Admin Dashboard",
-                    "filterable": false,
                     "permissions": [
                         {
                             "method": "withEmail",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -51,7 +51,8 @@
             "icon": "AnsibleIcon",
             "description": "Register your Ansible Automation Platform systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
           },
-          "ansible.tasks"
+          "ansible.tasks",
+          "ansible.ansibleWisdomAdminDashboard"
         ]
       }
     ]

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -130,7 +130,6 @@
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",
                     "title": "Admin Dashboard",
-                    "filterable": false,
                     "permissions": [
                         {
                             "method": "withEmail",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -51,7 +51,8 @@
             "icon": "AnsibleIcon",
             "description": "Register your Ansible Automation Platform systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
           },
-          "ansible.tasks"
+          "ansible.tasks",
+          "ansible.ansibleWisdomAdminDashboard"
         ]
       }
     ]


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-20139

This adds Ansible Lightspeed's Admin Dashboard to the discoverable "Automation" services configuration for staging.

Ansible's metrics dashboard ("Automation Analytics") are in the same services section; so it seems the most appropriate place.