### PR TITLE
Fix mixed links group entries casting.

### DIFF
--- a/cmd/search/publishSearchIndex.go
+++ b/cmd/search/publishSearchIndex.go
@@ -228,10 +228,10 @@ func flattenLinks(data interface{}, locator string) ([]LinkEntry, error) {
 }
 
 type groupLinkTemplate struct {
-	Id      string   `json:"id"`
-	IsGroup bool     `json:"isGroup"`
-	Title   string   `json:"title"`
-	Links   []string `json:"links"`
+	Id      string        `json:"id"`
+	IsGroup bool          `json:"isGroup"`
+	Title   string        `json:"title"`
+	Links   []interface{} `json:"links"`
 }
 
 type servicesTemplate struct {
@@ -300,7 +300,17 @@ func injectLinks(templateData []byte, flatLinks []LinkEntry) ([]ServiceEntry, er
 				if err == nil {
 					if ok {
 						for _, stringLink := range group.Links {
-							entry, found := findLinkById(stringLink, flatLinks)
+							var castLink string
+							castLink, ok = stringLink.(string)
+							var found bool
+							var entry ServiceLink
+							if ok {
+								entry, found = findLinkById(castLink, flatLinks)
+							}
+							/**
+							* Else branch is not handled because the link is "artificial" and does not exist in navigation.
+							* If a link is not in the navigation, it is not indexed.
+							 */
 							if found {
 								finalLinks = append(finalLinks, entry)
 							}


### PR DESCRIPTION
If a service group had one or more artificial link (not just ID reference), the entire group failed to be cast into the struct from which the string IDs and by extension the link entries are created.

So the entire group was missing from indexing.

Artificial links are now properly handled and ignored.