### PR TITLE
AAP-20139: Admin Dashboard: Add as 'Service' in HCC. Add icons

### DIFF
--- a/static/beta/stage/navigation/ansible-navigation.json
+++ b/static/beta/stage/navigation/ansible-navigation.json
@@ -130,6 +130,7 @@
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",
                     "title": "Admin Dashboard",
+                    "icon": "AnsibleIcon",
                     "permissions": [
                         {
                             "method": "withEmail",

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -130,6 +130,7 @@
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",
                     "title": "Admin Dashboard",
+                    "icon": "AnsibleIcon",
                     "permissions": [
                         {
                             "method": "withEmail",


### PR DESCRIPTION
Further to https://github.com/RedHatInsights/chrome-service-backend/pull/393

It was [noted](https://github.com/RedHatInsights/chrome-service-backend/pull/393#issuecomment-1921543553) that the "Service" entry lacked an Ansible icon.

This PR corrects it.