### PR TITLE
feat(ocp advisor): preparing nav for preview release

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -95,6 +95,7 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
+                            "isBeta": true,
                             "permissions": [
                                 {
                                   "method": "featureFlag",

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -94,6 +94,7 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
+                            "isBeta": true,
                             "permissions": [
                                 {
                                   "method": "featureFlag",

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -95,6 +95,7 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
+                            "isBeta": true,
                             "permissions": [
                                 {
                                   "method": "featureFlag",

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -94,6 +94,7 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
+                            "isBeta": true,
                             "permissions": [
                                 {
                                   "method": "featureFlag",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-7886
I am adding flag isBeta: true to the ocp advisor workloads navigation item 
so we can test it in stage preview and prod preview with feature flag on
after we see that it works as expected we're going to remove isBeta true from the prod configs and release it fully