### PR TITLE
AAP-20351: Admin Dashboard: Production[stable] release

### DIFF
--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -941,6 +941,25 @@
             }
         ]
     },
+    "ansibleWisdomAdminDashboard": {
+        "manifestLocation": "/apps/ansible-wisdom-admin-dashboard/fed-mods.json",
+        "config": {
+            "ssoScopes": [
+                "api.iam.access"
+            ]
+        },
+        "modules": [
+            {
+                "id": "ansible-wisdom-admin-dashboard",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/ansible/lightspeed-admin-dashboard"
+                    }
+                ]
+            }
+        ]
+    },
     "acs": {
         "manifestLocation": "/apps/acs/fed-mods.json",
         "modules": [

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -118,6 +118,20 @@
                     "title": "Seat Management",
                     "filterable": false,
                     "href": "/ansible/seats-administration"
+                },
+                {
+                    "id": "ansibleWisdomAdminDashboard",
+                    "appId": "ansibleWisdomAdminDashboard",
+                    "description": "Ansible Lightspeed administration dashboard.",
+                    "title": "Admin Dashboard",
+                    "icon": "AnsibleIcon",
+                    "permissions": [
+                        {
+                            "method": "withEmail",
+                            "args": ["@redhat.com"]
+                        }
+                    ],
+                    "href": "/ansible/lightspeed-admin-dashboard"
                 }
             ]
         },

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -52,7 +52,8 @@
             "icon": "AnsibleIcon",
             "description": "Register your Ansible Automation Platform systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
           },
-          "ansible.tasks"
+          "ansible.tasks",
+          "ansible.ansibleWisdomAdminDashboard"
         ]
       }
     ]


### PR DESCRIPTION
I have been told we have a "go live" date of ~this coming Thursday, 15th February.

I've told my managers that the RHCLOUD ticket is REVIEWED on Thursday and the changes complete shortly after.

I've also told them that this ticket has to follow after that.

---------------------------

See https://issues.redhat.com/browse/AAP-20351

Further to #397 this configures the applicable files for deployment to Production _stable_.

I've submitted a request for the networking side of things here: https://issues.redhat.com/browse/RHCLOUD-30987

Both this JIRA/PR and the reference `RHCLOUD` JIRA are for **PRODUCTION STABLE ONLY**.