### PR TITLE
Remove seatsAdminUi nav items

### DIFF
--- a/static/beta/prod/navigation/ansible-navigation.json
+++ b/static/beta/prod/navigation/ansible-navigation.json
@@ -112,14 +112,6 @@
             "expandable": true,
             "routes": [
                 {
-                    "id": "seatsAdminUi",
-                    "appId": "ansibleSeatsAdmin",
-                    "description": "Assign Ansible Lightspeed seats to users within your organization.",
-                    "title": "Seat Management",
-                    "filterable": false,
-                    "href": "/ansible/seats-administration"
-                },
-                {
                     "id": "ansibleWisdomAdminDashboard",
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",

--- a/static/beta/stage/navigation/ansible-navigation.json
+++ b/static/beta/stage/navigation/ansible-navigation.json
@@ -112,20 +112,6 @@
             "expandable": true,
             "routes": [
                 {
-                    "id": "seatsAdminUi",
-                    "appId": "ansibleSeatsAdmin",
-                    "description": "Assign Ansible Lightspeed seats to users within your organization.",
-                    "title": "Seat Management",
-                    "filterable": false,
-                    "permissions": [
-                        {
-                        "method": "withEmail",
-                        "args": ["@redhat.com", "@sbb.ch"]
-                        }
-                    ],
-                    "href": "/ansible/seats-administration"
-                },
-                {
                     "id": "ansibleWisdomAdminDashboard",
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -112,14 +112,6 @@
             "expandable": true,
             "routes": [
                 {
-                    "id": "seatsAdminUi",
-                    "appId": "ansibleSeatsAdmin",
-                    "description": "Assign Ansible Lightspeed seats to users within your organization.",
-                    "title": "Seat Management",
-                    "filterable": false,
-                    "href": "/ansible/seats-administration"
-                },
-                {
                     "id": "ansibleWisdomAdminDashboard",
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -112,20 +112,6 @@
             "expandable": true,
             "routes": [
                 {
-                    "id": "seatsAdminUi",
-                    "appId": "ansibleSeatsAdmin",
-                    "description": "Assign Ansible Lightspeed seats to users within your organization.",
-                    "title": "Seat Management",
-                    "filterable": false,
-                    "permissions": [
-                        {
-                        "method": "withEmail",
-                        "args": ["@redhat.com", "@sbb.ch"]
-                        }
-                    ],
-                    "href": "/ansible/seats-administration"
-                },
-                {
                     "id": "ansibleWisdomAdminDashboard",
                     "appId": "ansibleWisdomAdminDashboard",
                     "description": "Ansible Lightspeed administration dashboard.",


### PR DESCRIPTION
Removes nav menu items for seatsAdminUi in prod preview, prod stable, stage preview, and stage stable, as it's been deprecated in favor of the new Admin Dashboard.