### PR TITLE
updated nav for ocp workloads

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -95,7 +95,6 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
-                            "isBeta": true,
                             "permissions": [
                                 {
                                   "method": "featureFlag",

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -94,7 +94,6 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
-                            "isBeta": true,
                             "permissions": [
                                 {
                                   "method": "featureFlag",

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -88,20 +88,6 @@
                             "title": "Clusters",
                             "href": "/openshift/insights/advisor/clusters",
                             "product": "Red Hat OpenShift Cluster Manager"
-                        },
-                        {
-                            "id": "workloads",
-                            "appId": "ocpAdvisor",
-                            "title": "Workloads",
-                            "href": "/openshift/insights/advisor/workloads",
-                            "product": "Red Hat OpenShift Cluster Manager",
-                            "isBeta": true,
-                            "permissions": [
-                                {
-                                  "method": "featureFlag",
-                                  "args": ["ocp-advisor-ui-workloads", true]
-                                }
-                              ]
                         }
                     ]
                 },

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -94,7 +94,6 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
-                            "isBeta": true,
                             "permissions": [
                                 {
                                   "method": "featureFlag",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-7886
Updated navigation to hide the nav in stable prod but show it everywhere else