### PR TITLE
RHCLOUD-31267: Fix dashboard template API `sx` column errors on stage

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -36,6 +36,15 @@ func main() {
 		}
 	}
 
+	// temporary - removes unused typo column in dashboard template tables
+	if tx.Migrator().HasColumn(&models.DashboardTemplate{}, "sx") {
+		if err := tx.Migrator().DropColumn(&models.DashboardTemplate{}, "sx"); err != nil {
+			logrus.Error("Unable to migrate database!")
+			tx.Rollback()
+			panic(err)
+		}
+	}
+
 	if err := tx.AutoMigrate(&models.FavoritePage{}, &models.UserIdentity{}, &models.SelfReport{}, &models.ProductOfInterest{}, &models.DashboardTemplate{}); err != nil {
 		logrus.Error("Unable to migrate database!")
 		tx.Rollback()


### PR DESCRIPTION
I was able to get my local podman machine in the same scenario as console.stage.redhat.com as of now. The error is reproducible locally if:
1. Drop the dashboard template table entirely
1. Revert https://github.com/RedHatInsights/chrome-service-backend/pull/398
1. Run migrate script
1. Start chrome-service
1. Kill chrome service (without creating any table entries in dashboard templates)
1. Unrevert  https://github.com/RedHatInsights/chrome-service-backend/pull/398
1. Run migrate script
1. Start chrome service

Results in:
[ 'ERROR: null value in column "sx" of relation "dashboard_templates" violates not-null constraint (SQLSTATE 23502)' ]

After I added the small migrate script from this PR, everything works as intended:
```zsh
2024/02/29 14:18:44 /Users/bryan/Development/git/RedHatInsights/chrome-service-backend/rest/service/dashboardTemplate.go:44 ERROR: null value in column "sx" of relation "dashboard_templates" violates not-null constraint (SQLSTATE 23502)
[5.305ms] [rows:0] INSERT INTO "dashboard_templates" ("created_at","updated_at","deleted_at","user_identity_id","default","name","display_name","sm","md","lg","xl") VALUES ('2024-02-29 14:18:44.588','2024-02-29 14:18:44.588',NULL,1,true,'landingPage','Landing Page','[{"title":"Widget 1","i":"LargeWidget#lw1","x":0,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw2","x":0,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw3","x":0,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"MediumWidget#mw1","x":1,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw1","x":1,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw2","x":1,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true}]','[{"title":"Widget 1","i":"LargeWidget#lw1","x":0,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw2","x":0,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw3","x":0,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"MediumWidget#mw1","x":2,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw1","x":2,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw2","x":2,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true}]','[{"title":"Widget 1","i":"LargeWidget#lw1","x":0,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw2","x":0,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw3","x":0,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"MediumWidget#mw1","x":3,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw1","x":3,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw2","x":3,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true}]','[{"title":"Widget 1","i":"LargeWidget#lw1","x":0,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw2","x":0,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"LargeWidget#lw3","x":0,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"MediumWidget#mw1","x":4,"y":2,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw1","x":4,"y":0,"w":1,"h":1,"maxH":4,"minH":1,"static":true},{"title":"Widget 1","i":"SmallWidget#sw2","x":4,"y":1,"w":1,"h":1,"maxH":4,"minH":1,"static":true}]') RETURNING "id"
ERRO[0011] ERROR: null value in column "sx" of relation "dashboard_templates" violates not-null constraint (SQLSTATE 23502) 
INFO[0011] [bflorkie-mac] "GET http://localhost:8000/api/chrome-service/v1/dashboard-templates?dashboard=landingPage HTTP/1.1" from [::1]:58644 - 400 132B in 112.665893ms 
Sent: {AppName:chrome-service InstanceID:bryan-bflorkie-mac Bucket:{Start:2024-02-29 14:18:33.536705 -0500 EST m=+0.143028093 Stop:2024-02-29 14:19:33.53879 -0500 EST m=+60.143313511 Toggles:map[chrome-service.websockets.enabled:{Yes:0 No:1 Variants:map[]}]}}
^Csignal: interrupt
make: *** [dev] Error 1

➜  chrome-service-backend git:(fix-dashboard-template-db-errors) ✗ make migrate
go run cmd/migrate/migrate.go 
# command-line-arguments
ld: warning: -no_pie is deprecated when targeting new OS versions
ld: warning: non-standard -pagezero_size is deprecated when targeting macOS 13.0 or later
Database connection successful
INFO[0000] Migration complete                           
➜  chrome-service-backend git:(fix-dashboard-template-db-errors) make dev
go run cmd/unleash/seed.go
2024/02/29 14:21:26 {"id":"486b1c8e-6aa8-4203-8688-1d6e50b84e37","name":"AuthenticationRequired","message":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login","details":[{"message":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login","description":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login"}],"path":"/auth/simple/login","type":"password","defaultHidden":false}
2024/02/29 14:21:26 Flag chrome-service.websockets.enabled set to enabled with code 401
2024/02/29 14:21:26 {"id":"36d654ac-552f-47ac-9538-52afcb131ac8","name":"AuthenticationRequired","message":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login","details":[{"message":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login","description":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login"}],"path":"/auth/simple/login","type":"password","defaultHidden":false}
2024/02/29 14:21:26 Flag unit-test.true set to enabled with code 401
2024/02/29 14:21:26 {"id":"6addd20f-5142-4899-a1e6-1c53eb86041c","name":"AuthenticationRequired","message":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login","details":[{"message":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login","description":"You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login"}],"path":"/auth/simple/login","type":"password","defaultHidden":false}
go run main.go
# command-line-arguments
ld: warning: -no_pie is deprecated when targeting new OS versions
ld: warning: non-standard -pagezero_size is deprecated when targeting macOS 13.0 or later
Database connection successful
Registered: {AppName:chrome-service InstanceID:bryan-bflorkie-mac SDKVersion:unleash-client-go:3.7.3 Strategies:[default applicationHostname gradualRolloutRandom gradualRolloutSessionId gradualRolloutUserId remoteAddress userWithId flexibleRollout] Started:2024-02-29 14:21:30.427757 -0500 EST m=+0.143792231 Interval:60}
INFO[0000] Unleash client is ready                      
Counted 'chrome-service.websockets.enabled'  as enabled? false
```

Fixes https://issues.redhat.com/browse/RHCLOUD-31267