### PR TITLE
AAP-21505: Admin Dashboard: Remove RH email permission from RBAC configuration

### DIFF
--- a/static/beta/prod/navigation/ansible-navigation.json
+++ b/static/beta/prod/navigation/ansible-navigation.json
@@ -119,10 +119,6 @@
                     "icon": "AnsibleIcon",
                     "permissions": [
                         {
-                            "method": "withEmail",
-                            "args": ["@redhat.com"]
-                        },
-                        {
                             "method": "loosePermissions",
                             "args": [
                                 [

--- a/static/beta/stage/navigation/ansible-navigation.json
+++ b/static/beta/stage/navigation/ansible-navigation.json
@@ -119,10 +119,6 @@
                     "icon": "AnsibleIcon",
                     "permissions": [
                         {
-                            "method": "withEmail",
-                            "args": ["@redhat.com"]
-                        },
-                        {
                             "method": "loosePermissions",
                             "args": [
                                 [

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -119,10 +119,6 @@
                     "icon": "AnsibleIcon",
                     "permissions": [
                         {
-                            "method": "withEmail",
-                            "args": ["@redhat.com"]
-                        },
-                        {
                             "method": "loosePermissions",
                             "args": [
                                 [

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -119,10 +119,6 @@
                     "icon": "AnsibleIcon",
                     "permissions": [
                         {
-                            "method": "withEmail",
-                            "args": ["@redhat.com"]
-                        },
-                        {
                             "method": "loosePermissions",
                             "args": [
                                 [


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-21505

I have been requested to remove the `redhat.com` email restriction in all environments.