### PR TITLE
Show the Configure Events page for non org admin users (Stage)

### DIFF
--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -71,7 +71,7 @@
                         "method": "loosePermissions",
                           "args": [
                             "isOrgAdmin",
-                            "integrations::",
+                            "integrations:*:*",
                             "integrations:endpoints:write"
                         ]
                       }

--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -68,7 +68,12 @@
                     "href": "/settings/notifications/configure-events",
                     "permissions": [
                       {
-                        "method": "isOrgAdmin"
+                        "method": "loosePermissions",
+                          "args": [
+                            "isOrgAdmin",
+                            "integrations::",
+                            "integrations:endpoints:write"
+                        ]
                       }
                     ]
                 },

--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -70,7 +70,6 @@
                       {
                         "method": "loosePermissions",
                           "args": [
-                            "isOrgAdmin",
                             "integrations:*:*",
                             "integrations:endpoints:write"
                         ]

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -56,7 +56,6 @@
                     {
                         "method": "loosePermissions",
                         "args": [
-                            "isOrgAdmin",
                             "integrations:*:*",
                             "integrations:endpoints:write"
                         ]

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -57,7 +57,7 @@
                         "method": "loosePermissions",
                         "args": [
                             "isOrgAdmin",
-                            "integrations::",
+                            "integrations:*:*",
                             "integrations:endpoints:write"
                         ]
                     }

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -54,7 +54,12 @@
                   "href": "/settings/notifications/configure-events",
                   "permissions": [
                     {
-                      "method": "isOrgAdmin"
+                        "method": "loosePermissions",
+                        "args": [
+                            "isOrgAdmin",
+                            "integrations::",
+                            "integrations:endpoints:write"
+                        ]
                     }
                   ]
               },


### PR DESCRIPTION
[RHCLOUD-30431](https://issues.redhat.com/browse/RHCLOUD-30431)
- Allow users with `integrations:*:*` , `integrations:endpoints:write` to view the Configure Events page in stage beta and preview