### PR TITLE
HMS-3721: Update deployment to use the same appId (Stage only)

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1024,7 +1024,7 @@
             }
         ]
     },
-    "contentSources": {
+    "content-sources": {
         "manifestLocation": "/apps/content-sources/fed-mods.json",
         "defaultDocumentTitle": "Repositories",
         "modules": [
@@ -1034,9 +1034,6 @@
                 "routes": [
                     {
                         "pathname": "/insights/content"
-                    },
-                    {
-                        "pathname": "/settings/content"
                     }
                 ]
             }

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -174,7 +174,7 @@
         },
         {
           "id": "repositories",
-          "appId": "contentSources",
+          "appId": "content-sources",
           "title": "Repositories",
           "href": "/insights/content/repositories",
           "icon": "InsightsIcon",
@@ -209,20 +209,20 @@
           "description": "Link your external repositories to build images."
         },
         {
-            "id": "templates",
-            "appId": "contentSources",
-            "title": "Templates",
-            "href": "/insights/content/templates",
-            "icon": "InsightsIcon",
-            "product": "Red Hat Insights",
-            "subtitle": "Red Hat Insights for RHEL",
-            "alt_title": [
-              "template",
-              "add template",
-              "content",
-              "custom content"
-            ],
-            "description": "Create content templates for use with systems."
+          "id": "templates",
+          "appId": "content-sources",
+          "title": "Templates",
+          "href": "/insights/content/templates",
+          "icon": "InsightsIcon",
+          "product": "Red Hat Insights",
+          "subtitle": "Red Hat Insights for RHEL",
+          "alt_title": [
+            "template",
+            "add template",
+            "content",
+            "custom content"
+          ],
+          "description": "Create content templates for use with systems."
         },
         {
           "title": "Patch",

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -938,7 +938,7 @@
           }
       ]
   },
-  "contentSources": {
+  "content-sources": {
       "manifestLocation": "/apps/content-sources/fed-mods.json",
       "defaultDocumentTitle": "Repositories",
       "modules": [
@@ -948,9 +948,6 @@
               "routes": [
                   {
                       "pathname": "/insights/content"
-                  },
-                  {
-                      "pathname": "/settings/content"
                   }
               ]
           }

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -175,10 +175,10 @@
         },
         {
           "id": "repositories",
-          "appId": "contentSources",
+          "appId": "content-sources",
           "title": "Repositories",
-          "href": "/insights/content",
-          "icon": "SubscriptionsIcon",
+          "href": "/insights/content/repositories",
+          "icon": "InsightsIcon",
           "product": "Red Hat Insights",
           "subtitle": "Red Hat Insights for RHEL",
           "alt_title": [
@@ -208,6 +208,22 @@
             "yum"
           ],
           "description": "Link your external repositories to build images."
+        },
+        {
+          "id": "templates",
+          "appId": "content-sources",
+          "title": "Templates",
+          "href": "/insights/content/templates",
+          "icon": "InsightsIcon",
+          "product": "Red Hat Insights",
+          "subtitle": "Red Hat Insights for RHEL",
+          "alt_title": [
+            "template",
+            "add template",
+            "content",
+            "custom content"
+          ],
+          "description": "Create content templates for use with systems."
         },
         {
           "title": "Patch",


### PR DESCRIPTION
This updates the appId for fed-modules to be the same as seen in the navigation.json.
I will be "letting this bake" for some time before making the same appId change for the prod environment, in case there is some unforeseen usage of the changed appId elsewhere..

This change was brought to my attention and is highlighted in this [document](https://github.com/RedHatInsights/frontend-components/blob/master/packages/docs/pages/csc/examples.mdx). 

Additional changes: 
- Removed the /settings/content route, as that has been deprecated.
- Added the stage-stable content "templates" menu item (this is after testing was done in stage-beta).