### PR TITLE
Show the Configure Events page for non org admin users (Prod)

### DIFF
--- a/static/beta/prod/navigation/settings-navigation.json
+++ b/static/beta/prod/navigation/settings-navigation.json
@@ -54,7 +54,13 @@
                   "href": "/settings/notifications/configure-events",
                   "permissions": [
                     {
-                      "method": "isOrgAdmin"
+                      "method": "loosePermissions",
+                      "args": [
+                        [
+                          "integrations:*:*",
+                          "integrations:endpoints:write"
+                        ]
+                      ]
                     }
                   ]
               },

--- a/static/stable/prod/navigation/settings-navigation.json
+++ b/static/stable/prod/navigation/settings-navigation.json
@@ -54,7 +54,13 @@
                 "href": "/settings/notifications/configure-events",
                 "permissions": [
                   {
-                    "method": "isOrgAdmin"
+                    "method": "loosePermissions",
+                    "args": [
+                      [
+                        "integrations:*:*",
+                        "integrations:endpoints:write"
+                      ]
+                    ]
                   }
                 ]
             },


### PR DESCRIPTION
[RHCLOUD-30431](https://issues.redhat.com/browse/RHCLOUD-30431)

Allow users with integrations:*:* , integrations:endpoints:write to view the Configure Events page in production