### PR TITLE
Show the Configure Events page for non org admin users (Stage)

### DIFF
--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -69,11 +69,12 @@
                     "permissions": [
                       {
                         "method": "loosePermissions",
-                          "args": [
-                            [
-                              "integrations:*:*",
-                              "integrations:endpoints:write"
-                            ]
+                        "args": [
+                          [
+                            "notifications:*:*",
+                            "notifications:notifications:write",
+                            "notifications:notifications:read"
+                          ]
                         ]
                       }
                     ]

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -54,13 +54,14 @@
                   "href": "/settings/notifications/configure-events",
                   "permissions": [
                     {
-                        "method": "loosePermissions",
-                        "args": [
-                            [
-                                "integrations:*:*",
-                                "integrations:endpoints:write"
-                            ]
+                      "method": "loosePermissions",
+                      "args": [
+                        [
+                          "notifications:*:*",
+                          "notifications:notifications:write",
+                          "notifications:notifications:read"
                         ]
+                      ]
                     }
                   ]
               },


### PR DESCRIPTION
[RHCLOUD-30431](https://issues.redhat.com/browse/RHCLOUD-30431)

- Allow non org-admin users with `notifications:notifications:write` (can perform actions) and `notifications:notifications:read` (can read only) to view the Configure Events page in Stage