### PR TITLE
Add runtimes to federated modules in stage

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1145,5 +1145,9 @@
               ]
           }
         ]
+    },
+    "runtimes": {
+        "manifestLocation": "/apps/runtimes/fed-mods.json",
+        "modules": []
     }
 }

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -1124,5 +1124,9 @@
             ]
         }
       ]
+  },
+  "runtimes": {
+      "manifestLocation": "/apps/runtimes/fed-mods.json",
+      "modules": []
   }
 }


### PR DESCRIPTION
This PR adds [`runtimes`](https://github.com/redhatInsights/insights-runtimes-frontend) to the federated modules (in stage only at the moment), so that it's exported component(s) can be consumed by other apps within the HCC.
