### PR TITLE
remove openshift ai page; add new external links

### DIFF
--- a/static/beta/prod/navigation/application-services-navigation.json
+++ b/static/beta/prod/navigation/application-services-navigation.json
@@ -31,21 +31,6 @@
       ]
     },
     {
-      "groupId": "data-services",
-      "title": "Data Services",
-      "icon": "database",
-      "navItems": [
-        {
-          "id": "dataScience",
-          "appId": "applicationServices",
-          "title": "Red Hat OpenShift AI",
-          "href": "/application-services/data-science",
-          "icon": "DataScienceIcon",
-          "description": "Create, train, and serve artificial intelligence and machine learning (AI/ML) models."
-        }
-      ]
-    },
-    {
       "groupId": "trusted-content",
       "title": "Source Code Security",
       "icon": "shield",

--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -57,6 +57,25 @@
             "description": "Learn and try developing in a private, pre-configured OpenShift environment."
         },
         {
+            "groupId": "openshiftAI",
+            "title": "OpenShift AI",
+            "expandable": true,
+            "routes": [
+                {
+                    "id": "developersandboxtrial",
+                    "title": "On the Developer Sandbox",
+                    "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "isExternal": true
+                },
+                {
+                    "id": "sixtydaytrial",
+                    "title": "60-day product trial",
+                    "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "isExternal": true
+                }
+            ]
+        },
+        {
             "id": "downloads",
             "appId": "openshift",
             "href": "/openshift/downloads",

--- a/static/beta/stage/navigation/application-services-navigation.json
+++ b/static/beta/stage/navigation/application-services-navigation.json
@@ -31,21 +31,6 @@
       ]
     },
     {
-      "groupId": "data-services",
-      "title": "Data Services",
-      "icon": "database",
-      "navItems": [
-        {
-          "id": "dataScience",
-          "appId": "applicationServices",
-          "title": "Red Hat OpenShift AI",
-          "icon": "DataScienceIcon",
-          "href": "/application-services/data-science",
-          "description": "Create, train, and serve artificial intelligence and machine learning (AI/ML) models."
-        }
-      ]
-    },
-    {
       "groupId": "trusted-content",
       "title": "Source Code Security",
       "icon": "shield",

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -57,6 +57,30 @@
             "description": "Learn and try developing in a private, pre-configured OpenShift environment."
         },
         {
+            "title": "OpenShift AI",
+            "appId": "openshift",
+            "expandable": true,
+            "filterable": false,
+            "routes": [
+                {
+                    "id": "developersandboxtrial",
+                    "appId": "openshift",
+                    "title": "On the Developer Sandbox",
+                    "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "isExternal": true,
+                    "filterable": false
+                },
+                {
+                    "id": "sixtydaytrial",
+                    "appId": "openshift",
+                    "title": "60-day product trial",
+                    "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "isExternal": true,
+                    "filterable": false
+                }
+            ]
+        },
+        {
             "id": "downloads",
             "appId": "openshift",
             "href": "/openshift/downloads",

--- a/static/stable/prod/navigation/application-services-navigation.json
+++ b/static/stable/prod/navigation/application-services-navigation.json
@@ -16,21 +16,6 @@
       "href": "/application-services/learning-resources"
     },
     {
-      "groupId": "application-services",
-      "title": "Application Services",
-      "icon": "cloud",
-      "navItems": [
-        {
-          "id": "apiManagement",
-          "appId": "applicationServices",
-          "title": "API Management",
-          "icon": "ServicesIcon",
-          "description": "Manage API access, policy, and traffic controls for microservice-based applications.",
-          "href": "/application-services/api-management"
-        }
-      ]
-    },
-    {
       "groupId": "data-services",
       "title": "Data Services",
       "icon": "database",

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -57,6 +57,25 @@
             "description": "Learn and try developing in a private, pre-configured OpenShift environment."
         },
         {
+            "groupId": "openshiftAI",
+            "title": "OpenShift AI",
+            "expandable": true,
+            "routes": [
+                {
+                    "id": "developersandboxtrial",
+                    "title": "On the Developer Sandbox",
+                    "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "isExternal": true
+                },
+                {
+                    "id": "sixtydaytrial",
+                    "title": "60-day product trial",
+                    "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "isExternal": true
+                }
+            ]
+        },
+        {
             "id": "downloads",
             "appId": "openshift",
             "href": "/openshift/downloads",

--- a/static/stable/stage/navigation/application-services-navigation.json
+++ b/static/stable/stage/navigation/application-services-navigation.json
@@ -16,36 +16,6 @@
         "href": "/application-services/learning-resources"
     },
     {
-      "groupId": "application-services",
-      "title": "Application Services",
-      "icon": "cloud",
-      "navItems": [
-        {
-          "id": "apiManagement",
-          "appId": "applicationServices",
-          "title": "API Management",
-          "icon": "ServicesIcon",
-          "description": "Manage API access, policy, and traffic controls for microservice-based applications.",
-          "href": "/application-services/api-management"
-        }
-      ]
-    },
-    {
-      "groupId": "data-services",
-      "title": "Data Services",
-      "icon": "database",
-      "navItems": [
-        {
-          "id": "dataScience",
-          "appId": "applicationServices",
-          "title": "Red Hat OpenShift AI",
-          "href": "/application-services/data-science",
-          "icon": "DataScienceIcon",
-          "description": "Create, train, and serve artificial intelligence and machine learning (AI/ML) models."
-        }
-      ]
-    },
-    {
       "groupId": "trusted-content",
       "title": "Source Code Security",
       "icon": "shield",

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -57,6 +57,25 @@
             "description": "Learn and try developing in a private, pre-configured OpenShift environment."
         },
         {
+            "groupId": "openshiftAI",
+            "title": "OpenShift AI",
+            "expandable": true,
+            "routes": [
+                {
+                    "id": "developersandboxtrial",
+                    "title": "On the Developer Sandbox",
+                    "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "isExternal": true
+                },
+                {
+                    "id": "sixtydaytrial",
+                    "title": "60-day product trial",
+                    "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "isExternal": true
+                }
+            ]
+        },
+        {
             "id": "downloads",
             "appId": "openshift",
             "href": "/openshift/downloads",


### PR DESCRIPTION
for [RHCLOUD-29709](https://issues.redhat.com/browse/RHCLOUD-29709) This gets rid of Red Hat OpenShift AI from Application Services nav, and adds two external links to the OpenShift nav: product trials and sandbox. 

![image](https://github.com/RedHatInsights/chrome-service-backend/assets/16109803/701df21c-ff8a-4a36-96a3-6f33ea3f2b69)


![image](https://github.com/RedHatInsights/chrome-service-backend/assets/16109803/24b0fb2d-4f35-458d-bdce-424b07b8b9a6)
