### PR TITLE
Add header link to view event log

### DIFF
--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -51,6 +51,10 @@ var (
 			Module:   "./DashboardWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 2, 4, 1),
 			Config: models.WidgetConfiguration{
+				HeaderLink: models.WidgetHeaderLink{
+					Title: "View event log",
+					Href:  "/settings/notifications/eventlog",
+				},
 				Icon: models.BellIcon,
 			},
 		},


### PR DESCRIPTION
- Update the configuration for the `NotificationsEvents` widget to include a header link to `View event log`