### PR TITLE
AAP-21839: Ansible Lightspeed :: Admin Dashboard: :: RBAC permissions for new Active Users chart

### DIFF
--- a/static/beta/prod/navigation/ansible-navigation.json
+++ b/static/beta/prod/navigation/ansible-navigation.json
@@ -124,7 +124,8 @@
                                 [
                                     "ansible-wisdom-admin-dashboard:chart-recommendations:read",
                                     "ansible-wisdom-admin-dashboard:chart-user-sentiment:read",
-                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read"
+                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read",
+                                    "ansible-wisdom-admin-dashboard:chart-active-users:read"
                                 ]
                             ]
                         }

--- a/static/beta/stage/navigation/ansible-navigation.json
+++ b/static/beta/stage/navigation/ansible-navigation.json
@@ -124,7 +124,8 @@
                                 [
                                     "ansible-wisdom-admin-dashboard:chart-recommendations:read",
                                     "ansible-wisdom-admin-dashboard:chart-user-sentiment:read",
-                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read"
+                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read",
+                                    "ansible-wisdom-admin-dashboard:chart-active-users:read"
                                 ]
                             ]
                         }

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -124,7 +124,8 @@
                                 [
                                     "ansible-wisdom-admin-dashboard:chart-recommendations:read",
                                     "ansible-wisdom-admin-dashboard:chart-user-sentiment:read",
-                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read"
+                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read",
+                                    "ansible-wisdom-admin-dashboard:chart-active-users:read"
                                 ]
                             ]
                         }

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -124,7 +124,8 @@
                                 [
                                     "ansible-wisdom-admin-dashboard:chart-recommendations:read",
                                     "ansible-wisdom-admin-dashboard:chart-user-sentiment:read",
-                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read"
+                                    "ansible-wisdom-admin-dashboard:chart-module-usage:read",
+                                    "ansible-wisdom-admin-dashboard:chart-active-users:read"
                                 ]
                             ]
                         }


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-21839

This is just a continuation of already did in https://github.com/RedHatInsights/chrome-service-backend/pull/414 , but considering navigation also for a new RBAC permission recently being added (see https://github.com/RedHatInsights/rbac-config/pull/487)

Thanks!