### PR TITLE
add more openshift ai nav changes

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -67,6 +67,8 @@
                     "appId": "openshift",
                     "title": "On the Developer Sandbox",
                     "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 },
@@ -75,6 +77,8 @@
                     "appId": "openshift",
                     "title": "60-day product trial",
                     "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 }

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "ai",
+    "title": "AI/ML",
+    "links": [
+      {
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          "openshift.sixtydaytrial",
+          "openshift.developersandboxtrial"
+        ]
+      }
+    ]
+  },
+  {
     "id": "automation",
     "title": "Automation",
     "icon": "AutomationIcon",
@@ -481,25 +495,38 @@
     "description": "Our no-cost trials help you gain hands-on experience, prepare for a certification, or assess if a product is right for your organization.",
     "links": [
       {
-        "href": "/openshift/services/rosa/demo/",
-        "title": "ROSA Hands-on Experience",
-        "icon": "OpenShiftIcon",
-        "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+        "isGroup": true,
+        "title": "General Red Hat",
+        "links": [
+          {
+            "isExternal": true,
+            "href": "https://marketplace.redhat.com/en-us",
+            "title": "Red Hat Marketplace",
+            "icon": "RHIcon",
+            "description": "Find, try, purchase, and deploy your software across clouds."
+          },
+          {
+            "isExternal": true,
+            "href": "https://www.redhat.com/en/products/trials",
+            "title": "Red Hat Product Trials",
+            "icon": "RHIcon",
+            "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+          }
+        ]
       },
-      "openshift.developerSandbox",
       {
-        "isExternal": true,
-        "href": "https://marketplace.redhat.com/en-us",
-        "title": "Red Hat Marketplace",
-        "icon": "RHIcon",
-        "description": "Find, try, purchase, and deploy your software across clouds."
-      },
-      {
-        "isExternal": true,
-        "href": "https://www.redhat.com/en/products/trials",
-        "title": "Red Hat Product Trials",
-        "icon": "RHIcon",
-        "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          {
+            "href": "/openshift/services/rosa/demo/",
+            "title": "ROSA Hands-on Experience",
+            "icon": "OpenShiftIcon",
+            "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+          },
+          "openshift.developerSandbox",
+          "openshift.sixtydaytrial"
+        ]
       }
     ]
   }

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -67,6 +67,8 @@
                     "appId": "openshift",
                     "title": "On the Developer Sandbox",
                     "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 },
@@ -75,6 +77,8 @@
                     "appId": "openshift",
                     "title": "60-day product trial",
                     "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 }

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "ai",
+    "title": "AI/ML",
+    "links": [
+      {
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          "openshift.sixtydaytrial",
+          "openshift.developersandboxtrial"
+        ]
+      }
+    ]
+  },
+  {
     "id": "automation",
     "title": "Automation",
     "icon": "AutomationIcon",
@@ -483,25 +497,38 @@
     "description": "Our no-cost trials help you gain hands-on experience, prepare for a certification, or assess if a product is right for your organization.",
     "links": [
       {
-        "href": "/openshift/services/rosa/demo/",
-        "title": "ROSA Hands-on Experience",
-        "icon": "OpenShiftIcon",
-        "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+        "isGroup": true,
+        "title": "General Red Hat",
+        "links": [
+          {
+            "isExternal": true,
+            "href": "https://marketplace.redhat.com/en-us",
+            "title": "Red Hat Marketplace",
+            "icon": "RHIcon",
+            "description": "Find, try, purchase, and deploy your software across clouds."
+          },
+          {
+            "isExternal": true,
+            "href": "https://www.redhat.com/en/products/trials",
+            "title": "Red Hat Product Trials",
+            "icon": "RHIcon",
+            "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+          }
+        ]
       },
-      "openshift.developerSandbox",
       {
-        "isExternal": true,
-        "href": "https://marketplace.redhat.com/en-us",
-        "title": "Red Hat Marketplace",
-        "icon": "RHIcon",
-        "description": "Find, try, purchase, and deploy your software across clouds."
-      },
-      {
-        "isExternal": true,
-        "href": "https://www.redhat.com/en/products/trials",
-        "title": "Red Hat Product Trials",
-        "icon": "RHIcon",
-        "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          {
+            "href": "/openshift/services/rosa/demo/",
+            "title": "ROSA Hands-on Experience",
+            "icon": "OpenShiftIcon",
+            "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+          },
+          "openshift.developerSandbox",
+          "openshift.sixtydaytrial"
+        ]
       }
     ]
   }

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -67,6 +67,8 @@
                     "appId": "openshift",
                     "title": "On the Developer Sandbox",
                     "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 },
@@ -75,6 +77,8 @@
                     "appId": "openshift",
                     "title": "60-day product trial",
                     "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 }

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "ai",
+    "title": "AI/ML",
+    "links": [
+      {
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          "openshift.sixtydaytrial",
+          "openshift.developersandboxtrial"
+        ]
+      }
+    ]
+  },
+  {
     "id": "dataset",
     "icon": "LightBulbIcon",
     "title": "AI/ML",
@@ -495,25 +509,38 @@
     "description": "Our no-cost trials help you gain hands-on experience, prepare for a certification, or assess if a product is right for your organization.",
     "links": [
       {
-        "href": "/openshift/services/rosa/demo/",
-        "title": "ROSA Hands-on Experience",
-        "icon": "OpenShiftIcon",
-        "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+        "isGroup": true,
+        "title": "General Red Hat",
+        "links": [
+          {
+            "isExternal": true,
+            "href": "https://marketplace.redhat.com/en-us",
+            "title": "Red Hat Marketplace",
+            "icon": "RHIcon",
+            "description": "Find, try, purchase, and deploy your software across clouds."
+          },
+          {
+            "isExternal": true,
+            "href": "https://www.redhat.com/en/products/trials",
+            "title": "Red Hat Product Trials",
+            "icon": "RHIcon",
+            "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+          }
+        ]
       },
-      "openshift.developerSandbox",
       {
-        "isExternal": true,
-        "href": "https://marketplace.redhat.com/en-us",
-        "title": "Red Hat Marketplace",
-        "icon": "RHIcon",
-        "description": "Find, try, purchase, and deploy your software across clouds."
-      },
-      {
-        "isExternal": true,
-        "href": "https://www.redhat.com/en/products/trials",
-        "title": "Red Hat Product Trials",
-        "icon": "RHIcon",
-        "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          {
+            "href": "/openshift/services/rosa/demo/",
+            "title": "ROSA Hands-on Experience",
+            "icon": "OpenShiftIcon",
+            "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+          },
+          "openshift.developerSandbox",
+          "openshift.sixtydaytrial"
+        ]
       }
     ]
   }

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -67,6 +67,8 @@
                     "appId": "openshift",
                     "title": "On the Developer Sandbox",
                     "href": "https://developers.redhat.com/learn/openshift/how-create-natural-language-processing-nlp-application-using-red-hat-openshift-ai",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 },
@@ -75,6 +77,8 @@
                     "appId": "openshift",
                     "title": "60-day product trial",
                     "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial",
+                    "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
+                    "icon": "AITechnologyIcon",
                     "isExternal": true,
                     "filterable": false
                 }

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "ai",
+    "title": "AI/ML",
+    "links": [
+      {
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          "openshift.sixtydaytrial",
+          "openshift.developersandboxtrial"
+        ]
+      }
+    ]
+  },
+  {
     "id": "automation",
     "title": "Automation",
     "icon": "AutomationIcon",
@@ -473,25 +487,38 @@
     "description": "Our no-cost trials help you gain hands-on experience, prepare for a certification, or assess if a product is right for your organization.",
     "links": [
       {
-        "href": "/openshift/services/rosa/demo/",
-        "title": "ROSA Hands-on Experience",
-        "icon": "OpenShiftIcon",
-        "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+        "isGroup": true,
+        "title": "General Red Hat",
+        "links": [
+          {
+            "isExternal": true,
+            "href": "https://marketplace.redhat.com/en-us",
+            "title": "Red Hat Marketplace",
+            "icon": "RHIcon",
+            "description": "Find, try, purchase, and deploy your software across clouds."
+          },
+          {
+            "isExternal": true,
+            "href": "https://www.redhat.com/en/products/trials",
+            "title": "Red Hat Product Trials",
+            "icon": "RHIcon",
+            "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+          }
+        ]
       },
-      "openshift.developerSandbox",
       {
-        "isExternal": true,
-        "href": "https://marketplace.redhat.com/en-us",
-        "title": "Red Hat Marketplace",
-        "icon": "RHIcon",
-        "description": "Find, try, purchase, and deploy your software across clouds."
-      },
-      {
-        "isExternal": true,
-        "href": "https://www.redhat.com/en/products/trials",
-        "title": "Red Hat Product Trials",
-        "icon": "RHIcon",
-        "description": "Gain hands-on experience and assess if a product is right for you in a no-cost trial."
+        "isGroup": true,
+        "title": "OpenShift",
+        "links": [
+          {
+            "href": "/openshift/services/rosa/demo/",
+            "title": "ROSA Hands-on Experience",
+            "icon": "OpenShiftIcon",
+            "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
+          },
+          "openshift.developerSandbox",
+          "openshift.sixtydaytrial"
+        ]
       }
     ]
   }


### PR DESCRIPTION
[RHCLOUD-29709](https://issues.redhat.com/browse/RHCLOUD-29709)
This adds descriptions and icons to the new OpenShift AI cards, and adds them to the Try and Buy category

Sketch: https://www.sketch.com/s/18a43d9a-bebd-4f43-805f-521bf2b7c3fe/prototype/D89EFB55-95A4-4DD1-81B3-EFC9F008CCEC/a/23200B52-100B-4141-B687-FAAB77DA030B

![Screenshot_20240402_123425](https://github.com/RedHatInsights/chrome-service-backend/assets/16109803/29e89d1b-adc6-44a8-a699-918db142c6fa)

![image](https://github.com/RedHatInsights/chrome-service-backend/assets/16109803/3f7a260e-965b-4243-82e0-755419fb718f)





