### PR TITLE
feat(RHINENG-9134): add second feature flag for a release

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -123,10 +123,14 @@
                             "title": "Workloads",
                             "href": "/openshift/insights/advisor/workloads",
                             "product": "Red Hat OpenShift Cluster Manager",
-                            "permissions": [
+                            "loosePermissions": [
                                 {
                                   "method": "featureFlag",
                                   "args": ["ocp-advisor-ui-workloads", true]
+                                },
+                                {
+                                    "method": "featureFlag",
+                                    "args": ["ocp-advisor-workloads-release", true]
                                 }
                               ]
                         }

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -126,6 +126,10 @@
                                 {
                                   "method": "featureFlag",
                                   "args": ["ocp-advisor-ui-workloads", true]
+                                },
+                                {
+                                    "method": "featureFlag",
+                                    "args": ["ocp-advisor-workloads-release", true]
                                 }
                               ]
                         }

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -116,6 +116,24 @@
                             "title": "Clusters",
                             "href": "/openshift/insights/advisor/clusters",
                             "product": "Red Hat OpenShift Cluster Manager"
+                        },
+                        {
+                            "id": "workloads",
+                            "appId": "ocpAdvisor",
+                            "title": "Workloads",
+                            "href": "/openshift/insights/advisor/workloads",
+                            "product": "Red Hat OpenShift Cluster Manager",
+                            "isBeta": true,
+                            "permissions": [
+                                {
+                                "method": "featureFlag",
+                                "args": ["ocp-advisor-ui-workloads", true]
+                                },
+                                {
+                                "method": "featureFlag",
+                                "args": ["ocp-advisor-workloads-release", true]
+                                }
+                            ]
                         }
                     ]
                 },

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -126,6 +126,10 @@
                                 {
                                   "method": "featureFlag",
                                   "args": ["ocp-advisor-ui-workloads", true]
+                                },
+                                {
+                                    "method": "featureFlag",
+                                    "args": ["ocp-advisor-workloads-release", true]
                                 }
                               ]
                         }


### PR DESCRIPTION
Added navigation to the prod stable config.
I added a second flag to make sure that we can release a new feature with only 1 button

I added a stage flags so we can test it before GA on Monday
I change permissions to loose permission in prod preview because some of the clients already have access to the product