### PR TITLE
Add runtimes to federated modules in prod

### DIFF
--- a/static/beta/prod/modules/fed-modules.json
+++ b/static/beta/prod/modules/fed-modules.json
@@ -1021,5 +1021,9 @@
     "virtualAssistant": {
       "manifestLocation": "/apps/virtual-assistant/fed-mods.json",
       "modules": []
+    },
+    "runtimes": {
+        "manifestLocation": "/apps/runtimes/fed-mods.json",
+        "modules": []
     }
 }

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -961,5 +961,9 @@
     "virtualAssistant": {
       "manifestLocation": "/apps/virtual-assistant/fed-mods.json",
       "modules": []
+    },
+    "runtimes": {
+        "manifestLocation": "/apps/runtimes/fed-mods.json",
+        "modules": []
     }
 }


### PR DESCRIPTION
This PR adds "runtimes" to the federated modules in prod.

This is the follow-up PR to the one merged last month to add runtimes to stage (https://github.com/RedHatInsights/chrome-service-backend/pull/436).