### PR TITLE
fix(RHINENG-7102): Address search issues for Insights entries

### DIFF
--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -4,37 +4,6 @@
     "links": [
       {
         "custom": true,
-        "id": "OPENSHIFT.insights.Advisor.recommendations",
-        "href": "/openshift/insights/advisor/recommendations",
-        "title": "Red Hat OpenShift Cluster Manager Recommendations",
-        "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security.",
-        "alt_title": [
-          "Insights Advisor",
-          "OpenShift Advisor",
-          "Advisor",
-          "Recommendations",
-          "Proactive support",
-          "Proactive support",
-          "risk",
-          "support",
-          "update",
-          "update risk",
-          "update",
-          "issues",
-          "remediation",
-          "cluster state",
-          "recommendation",
-          "cluster health",
-          "remote health",
-          "proactive",
-          "support",
-          "fix",
-          "problem",
-          "issue"
-        ]
-      },
-      {
-        "custom": true,
         "id": "OPENSHIFT.insights.Advisor.advisor-clusters",
         "href": "/openshift/insights/advisor/clusters",
         "title": "Red Hat OpenShift Cluster Manager Advisor",

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -541,40 +541,6 @@
     ]
   },
   {
-    "id": "rhel-advisor",
-    "links": [
-      {
-        "custom": true,
-        "id": "RHEL.advisor",
-        "href": "/insights/advisor/recommendations",
-        "title": "Insights Advisor",
-        "subtitle": "Red Hat Insights for RHEL",
-        "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems’ availability, performance, and security.",
-        "alt_title": [
-          "advisor",
-          "Rules",
-          "rules",
-          "rule",
-          "Rule",
-          "insights",
-          "security",
-          "stability",
-          "performance",
-          "incidents",
-          "recommendations",
-          "configuration",
-          "pathways",
-          "critical",
-          "upgrade",
-          "upgrade risk",
-          "incident",
-          "recommendation",
-          "pathway"
-        ]
-      }
-    ]
-  },
-  {
     "id": "rhel-remediations",
     "links": [
       {

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -204,7 +204,8 @@
           "updates",
           "content templates"
         ]
-      }
+      },
+      "rhel.packages"
     ]
   },
   {
@@ -226,40 +227,6 @@
           "patching",
           "update",
           "content view"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "rhel-content-patch-packages",
-    "links": [
-      {
-        "custom": true,
-        "id": "RHEL.patch",
-        "href": "/insights/patch/packages",
-        "description": "Review package applicability on your Red Hat Enterprise Linux systems.",
-        "title": "Packages",
-        "alt_title": [
-          "Packages",
-          "updates",
-          "insights",
-          "repositories",
-          "rpm",
-          "dnf",
-          "yum",
-          "errata",
-          "Errata",
-          "patch",
-          "advisories",
-          "patching",
-          "templates",
-          "content management",
-          "content view",
-          "patch cycle",
-          "satellite",
-          "RHSA",
-          "RHBA",
-          "RHEA"
         ]
       }
     ]

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -210,6 +210,7 @@
           "dnf",
           "yum",
           "errata",
+          "Errata",
           "patch",
           "advisories",
           "patching",
@@ -272,6 +273,7 @@
           "dnf",
           "yum",
           "errata",
+          "Errata",
           "patch",
           "advisories",
           "patching",
@@ -372,7 +374,8 @@
           "cvss",
           "risk",
           "critical",
-          "errata"
+          "errata",
+          "Errata"
         ]
       },
       {
@@ -400,7 +403,8 @@
           "cvss",
           "risk",
           "critical",
-          "errata"
+          "errata",
+          "Errata"
         ]
       }
     ]
@@ -725,6 +729,7 @@
           "critical",
           "security rule",
           "errata",
+          "Errata",
           "affected but not vulnerable",
           "severity",
           "CVE-"

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -659,11 +659,24 @@
         "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems’ availability, performance, and security.",
         "alt_title": [
           "advisor",
+          "Rules",
+          "rules",
+          "rule",
+          "Rule",
+          "insights",
+          "security",
+          "stability",
+          "performance",
           "incidents",
           "recommendations",
           "configuration",
           "pathways",
-          "critical"
+          "critical",
+          "upgrade",
+          "upgrade risk",
+          "incident",
+          "recommendation",
+          "pathway"
         ]
       }
     ]

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -172,31 +172,6 @@
     ]
   },
   {
-    "id": "patch-system",
-    "links": [
-      {
-        "custom": true,
-        "id": "RHEL.Content.Patch.patch",
-        "href": "/insights/patch/systems",
-        "title": "Systems",
-        "subtitle": "Red Hat Insights for RHEL",
-        "description": "View details about your Red Hat Enterprise Linux systems and their applicable advisories.",
-        "alt_title": [
-          "Patch",
-          "content",
-          "advisories",
-          "insights",
-          "Rhel",
-          "patch",
-          "updates",
-          "update",
-          "systems",
-          "upgrade"
-        ]
-      }
-    ]
-  },
-  {
     "id": "rhel-patch",
     "links": [
       {

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -494,32 +494,6 @@
     ]
   },
   {
-    "id": "rhel-policies",
-    "links": [
-      {
-        "custom": true,
-        "id": "RHEL.policies",
-        "href": "/insights/policies",
-        "title": "RHEL Policies",
-        "description": "Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.",
-        "alt_title":[
-          "policies",
-          "facts",
-          "conditions",
-          "trigger", "notifications",
-          "alerts",
-          "insights",
-          "notify",
-          "integration",
-          "conditions",
-          "alerts",
-          "events",
-          "raise alerts on system configuration changes"
-        ]
-      }
-    ]
-  },
-  {
     "id": "costManagement",
     "links": [
       {

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -607,33 +607,6 @@
     ]
   },
   {
-    "id": "rhel-tasks",
-    "links": [
-      {
-        "custom": true,
-        "id": "RHEL.tasks",
-        "href": "/insights/tasks",
-        "title": "RHEL Tasks",
-        "description": "Perform Red Hat-recommended analysis across your Red Hat Enterprise Linux fleet, like upgrade and conversion readiness.",
-        "alt_title": [
-          "Task",
-          "upgrade",
-          "update",
-          "insights",
-          "automation",
-          "leapp",
-          "migrate",
-          "version",
-          "9.0",
-          "8.0",
-          "convert",
-          "conversion",
-          "migration"
-        ]
-      }
-    ]
-  },
-  {
     "id": "rhel-dashboard",
     "links": [
       {

--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -564,7 +564,9 @@
         "alt_title": [
           "Compliance",
           "security",
-          "regulatory"
+          "regulatory",
+          "rules",
+          "rule"
         ],
         "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards."
       },
@@ -577,7 +579,9 @@
         "alt_title": [
           "SCAP",
           "security content automation protocol",
-          "policies"
+          "policies",
+          "rules",
+          "rule"
         ]
       }
     ]

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -117,7 +117,20 @@
               "appId": "patch",
               "title": "Systems",
               "href": "/insights/patch/systems",
-              "product": "Red Hat Insights"
+              "product": "Red Hat Insights",
+              "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
+              "alt_title": [
+                "Patch",
+                "content",
+                "advisories",
+                "insights",
+                "Rhel",
+                "patch",
+                "updates",
+                "update",
+                "systems",
+                "upgrade"
+              ]
             },
             {
               "id": "patchTemplates",

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -70,7 +70,30 @@
           "href": "/insights/patch/packages",
           "icon": "InsightsIcon",
           "product": "Red Hat Insights",
-          "subtitle": "Red Hat Insights for RHEL"
+          "subtitle": "Red Hat Insights for RHEL",
+          "description": "Review package applicability on your Red Hat Enterprise Linux systems.",
+          "alt_title": [
+            "Packages",
+            "updates",
+            "insights",
+            "repositories",
+            "rpm",
+            "dnf",
+            "yum",
+            "errata",
+            "Errata",
+            "patch",
+            "advisories",
+            "patching",
+            "templates",
+            "content management",
+            "content view",
+            "patch cycle",
+            "satellite",
+            "RHSA",
+            "RHBA",
+            "RHEA"
+          ]
         },
         {
           "id": "repositories",

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -437,7 +437,19 @@
             "CentOS",
             "centos",
             "Centos",
-            "centOS"
+            "centOS",
+            "upgrade",
+            "update",
+            "insights",
+            "automation",
+            "leapp",
+            "migrate",
+            "version",
+            "9.0",
+            "8.0",
+            "convert",
+            "conversion",
+            "migration"
           ]
         }
       ]

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -51,6 +51,7 @@
           "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
           "alt_title": [
             "Errata",
+            "errata",
             "patch",
             "updates",
             "insights"
@@ -268,6 +269,7 @@
             "critical",
             "security rule",
             "errata",
+            "Errata",
             "affected but not vulnerable",
             "severity", 
             "CVE-"

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -209,10 +209,24 @@
           "id": "policies",
           "appId": "policies",
           "title": "Policies",
-          "href": "/insights/policies/policies/list",
+          "href": "/insights/policies",
           "icon": "InsightsIcon",
           "subtitle": "Red Hat Insights for RHEL",
-          "description": "Monitor your RHEL hosts against set parameters to detect deviation or misalignment."
+          "description": "Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.",
+          "alt_title":[
+            "policies",
+            "facts",
+            "conditions",
+            "trigger", "notifications",
+            "alerts",
+            "insights",
+            "notify",
+            "integration",
+            "conditions",
+            "alerts",
+            "events",
+            "raise alerts on system configuration changes"
+          ]
         }
       ]
     },

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -308,7 +308,6 @@
               "product": "Red Hat Insights",
               "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
               "alt_title": [
-                "Compliance",
                 "security",
                 "policies",
                 "SCAP",

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -32,7 +32,13 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
+          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
+          "alt_title": [
+            "group",
+            "groups",
+            "Group",
+            "Groups"
+          ]          
         }
       ]
     },

--- a/static/beta/itless/services/services.json
+++ b/static/beta/itless/services/services.json
@@ -54,7 +54,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/drift",
@@ -84,7 +105,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/vulnerability/cves",

--- a/static/beta/itless/services/services.json
+++ b/static/beta/itless/services/services.json
@@ -98,13 +98,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          {
-            "href": "/insights/compliance/reports",
-            "icon": "InsightsIcon",
-            "title": "Compliance",
-            "subtitle":"Red Hat Insights for RHEL",
-            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards."
-          },
+          "rhel.complianceReports",
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/beta/itless/services/services.json
+++ b/static/beta/itless/services/services.json
@@ -48,12 +48,7 @@
         "links": [
           "rhel.advisories",
           "rhel.repositories",
-          {
-            "href": "/insights/patch/systems",
-            "title": "Patch",
-            "icon": "InsightsIcon",
-            "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems."
-          },
+          "rhel.patchSystems",
           {
             "href": "/insights/advisor/recommendations",
             "title": "Advisor",

--- a/static/beta/itless/services/services.json
+++ b/static/beta/itless/services/services.json
@@ -24,12 +24,7 @@
         "title": "Red Hat Enterprise Linux",
         "links": [
           "rhel.inventory",
-          {
-            "title": "Inventory Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon",
-            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
-          }
+          "rhel.groups"
         ]
       },
       {

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -160,6 +160,7 @@
           "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
           "alt_title": [
             "Errata",
+            "errata",
             "patch",
             "updates",
             "insights"
@@ -373,6 +374,7 @@
             "critical",
             "security rule",
             "errata",
+            "Errata",
             "affected but not vulnerable",
             "severity", 
             "CVE-"

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -174,12 +174,36 @@
           ]
         },
         {
+          "id": "packages",
           "appId": "patch",
           "title": "Packages",
           "href": "/insights/patch/packages",
           "icon": "InsightsIcon",
           "product": "Red Hat Insights",
-          "subtitle": "Red Hat Insights for RHEL"
+          "subtitle": "Red Hat Insights for RHEL",
+          "description": "Review package applicability on your Red Hat Enterprise Linux systems.",
+          "alt_title": [
+            "Packages",
+            "updates",
+            "insights",
+            "repositories",
+            "rpm",
+            "dnf",
+            "yum",
+            "errata",
+            "Errata",
+            "patch",
+            "advisories",
+            "patching",
+            "templates",
+            "content management",
+            "content view",
+            "patch cycle",
+            "satellite",
+            "RHSA",
+            "RHBA",
+            "RHEA"
+          ]
         },
         {
           "id": "repositories",

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -100,6 +100,7 @@
               "description": "Configure your systems to execute Ansible Playbooks.",
               "alt_title": [
                 "Remote host configuration",
+                "remote host configuration",
                 "connect systems",
                 "connection options",
                 "connect settings",

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -317,7 +317,21 @@
           "href": "/insights/policies",
           "icon": "InsightsIcon",
           "subtitle": "Red Hat Insights for RHEL",
-          "description": "Monitor your RHEL hosts against set parameters to detect deviation or misalignment."
+          "description": "Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.",
+          "alt_title":[
+            "policies",
+            "facts",
+            "conditions",
+            "trigger", "notifications",
+            "alerts",
+            "insights",
+            "notify",
+            "integration",
+            "conditions",
+            "alerts",
+            "events",
+            "raise alerts on system configuration changes"
+          ]
         }
       ]
     },

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -414,7 +414,6 @@
               "product": "Red Hat Insights",
               "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
               "alt_title": [
-                "Compliance",
                 "security",
                 "policies",
                 "SCAP",

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -551,7 +551,19 @@
             "CentOS",
             "centos",
             "Centos",
-            "centOS"
+            "centOS",
+            "upgrade",
+            "update",
+            "insights",
+            "automation",
+            "leapp",
+            "migrate",
+            "version",
+            "9.0",
+            "8.0",
+            "convert",
+            "conversion",
+            "migration"
           ]
         }
       ]

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -33,7 +33,13 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."          
+          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
+          "alt_title": [
+            "group",
+            "groups",
+            "Group",
+            "Groups"
+          ]          
         },
         {
           "id": "imageBuilder",

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -222,10 +222,24 @@
           "expandable": true,
           "routes": [
             {
+              "id": "patchSystems",
               "appId": "patch",
               "title": "Systems",
               "href": "/insights/patch/systems",
-              "product": "Red Hat Insights"
+              "product": "Red Hat Insights",
+              "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
+              "alt_title": [
+                "Patch",
+                "content",
+                "advisories",
+                "insights",
+                "Rhel",
+                "patch",
+                "updates",
+                "update",
+                "systems",
+                "upgrade"
+              ]
             },
             {
               "appId": "patch",

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -565,7 +565,13 @@
       "icon": "InsightsIcon",
       "product": "Red Hat Insights",
       "subtitle": "Red Hat Insights for RHEL",
-      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
+      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console.",
+      "alt_title": [
+        "register rhel",
+        "Register RHEL",
+        "rhel",
+        "RHEL"
+      ]
     },
     {
       "id": "learningResources",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -318,13 +318,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          {
-            "href": "/insights/compliance/reports",
-            "icon": "InsightsIcon",
-            "title": "Compliance",
-            "subtitle":"Red Hat Insights for RHEL",
-            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards."
-          },
+          "rhel.complianceReports",
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -450,13 +450,7 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "href": "/insights/connector",
-            "title": "Remote Host Configuration (RHC)",
-            "icon": "InsightsIcon",
-            "subtitle": "Red Hat Insights for RHEL",
-            "description": "Configure your systems to execute Ansible Playbooks."
-          },
+          "rhel.rhc",
           "rhel.activationKeys",
           "rhel.registerSystems",
           "rhel.stalenessAndDeletion"

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -308,7 +308,24 @@
             "title": "Advisor",
             "subtitle": "Red Hat Insights for Ansible",
             "icon": "AnsibleIcon",
-            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security.",
+            "alt_title": [
+              "Rules",
+              "recommendations",
+              "Configuration",
+              "security",
+              "stability",
+              "performance",
+              "advisor",
+              "incidents",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "title": "Drift",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -221,7 +221,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/drift",
@@ -304,7 +325,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/vulnerability/cves",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -263,7 +263,32 @@
             "icon": "OpenShiftIcon",
             "title": "Advisor",
             "subtitle": "Red Hat Insights for OpenShift",
-            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security.",
+            "alt_title": [
+              "Insights Advisor",
+              "OpenShift Advisor",
+              "Advisor",
+              "advisor",
+              "Recommendations",
+              "Proactive support",
+              "Proactive support",
+              "risk",
+              "support",
+              "update",
+              "update risk",
+              "update",
+              "issues",
+              "remediation",
+              "cluster state",
+              "recommendation",
+              "cluster health",
+              "remote health",
+              "proactive",
+              "support",
+              "fix",
+              "problem",
+              "issue"
+            ]
           },
           {
             "href": "/openshift/insights/vulnerability/cves",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -176,12 +176,8 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.inventory",
-          {
-            "title": "Inventory Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon",
-            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
-          }
+          "rhel.groups"
+
         ]
       },
       {

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -215,12 +215,7 @@
         "links": [
           "rhel.advisories",
           "rhel.repositories",
-          {
-            "href": "/insights/patch/systems",
-            "title": "Patch",
-            "icon": "InsightsIcon",
-            "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems."
-          },
+          "rhel.patchSystems",
           {
             "href": "/insights/advisor/recommendations",
             "title": "Advisor",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -159,6 +159,7 @@
           "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
           "alt_title": [
             "Errata",
+            "errata",
             "patch",
             "updates",
             "insights"
@@ -388,6 +389,7 @@
             "critical",
             "security rule",
             "errata",
+            "Errata",
             "affected but not vulnerable",
             "severity", 
             "CVE-"

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -332,7 +332,21 @@
           "href": "/insights/policies",
           "icon": "InsightsIcon",
           "subtitle": "Red Hat Insights for RHEL",
-          "description": "Monitor your RHEL hosts against set parameters to detect deviation or misalignment."
+          "description": "Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.",
+          "alt_title":[
+            "policies",
+            "facts",
+            "conditions",
+            "trigger", "notifications",
+            "alerts",
+            "insights",
+            "notify",
+            "integration",
+            "conditions",
+            "alerts",
+            "events",
+            "raise alerts on system configuration changes"
+          ]
         }
       ]
     },

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -429,7 +429,6 @@
               "product": "Red Hat Insights",
               "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
               "alt_title": [
-                "Compliance",
                 "security",
                 "policies",
                 "SCAP",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -99,6 +99,7 @@
               "description": "Configure your systems to execute Ansible Playbooks.",
               "alt_title": [
                 "Remote host configuration",
+                "remote host configuration",
                 "connect systems",
                 "connection options",
                 "connect settings",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -173,12 +173,36 @@
           ]
         },
         {
+          "id": "packages",
           "appId": "patch",
           "title": "Packages",
           "href": "/insights/patch/packages",
           "icon": "InsightsIcon",
           "product": "Red Hat Insights",
-          "subtitle": "Red Hat Insights for RHEL"
+          "subtitle": "Red Hat Insights for RHEL",
+          "description": "Review package applicability on your Red Hat Enterprise Linux systems.",
+          "alt_title": [
+            "Packages",
+            "updates",
+            "insights",
+            "repositories",
+            "rpm",
+            "dnf",
+            "yum",
+            "errata",
+            "Errata",
+            "patch",
+            "advisories",
+            "patching",
+            "templates",
+            "content management",
+            "content view",
+            "patch cycle",
+            "satellite",
+            "RHSA",
+            "RHBA",
+            "RHEA"
+          ]
         },
         {
           "id": "repositories",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -32,7 +32,13 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
+          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
+          "alt_title": [
+            "group",
+            "groups",
+            "Group",
+            "Groups"
+          ]          
         },
         {
           "id": "imageBuilder",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -237,10 +237,24 @@
           "expandable": true,
           "routes": [
             {
+              "id": "patchSystems",
               "appId": "patch",
               "title": "Systems",
               "href": "/insights/patch/systems",
-              "product": "Red Hat Insights"
+              "product": "Red Hat Insights",
+              "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
+              "alt_title": [
+                "Patch",
+                "content",
+                "advisories",
+                "insights",
+                "Rhel",
+                "patch",
+                "updates",
+                "update",
+                "systems",
+                "upgrade"
+              ]
             },
             {
               "appId": "patch",

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -566,7 +566,19 @@
             "CentOS",
             "centos",
             "Centos",
-            "centOS"
+            "centOS",
+            "upgrade",
+            "update",
+            "insights",
+            "automation",
+            "leapp",
+            "migrate",
+            "version",
+            "9.0",
+            "8.0",
+            "convert",
+            "conversion",
+            "migration"
           ]
         }
       ]

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -580,7 +580,13 @@
       "icon": "InsightsIcon",
       "product": "Red Hat Insights",
       "subtitle": "Red Hat Insights for RHEL",
-      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
+      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console.",
+      "alt_title": [
+        "register rhel",
+        "Register RHEL",
+        "rhel",
+        "RHEL"
+      ]   
     },
     {
       "id": "learningResources",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -318,13 +318,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          {
-            "href": "/insights/compliance/reports",
-            "icon": "InsightsIcon",
-            "title": "Compliance",
-            "subtitle":"Red Hat Insights for RHEL",
-            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards."
-          },
+          "rhel.complianceReports",
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -460,13 +460,7 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "href": "/insights/connector",
-            "title": "Remote Host Configuration (RHC)",
-            "icon": "InsightsIcon",
-            "subtitle": "Red Hat Insights for RHEL",
-            "description": "Configure your systems to execute Ansible Playbooks."
-          },
+          "rhel.rhc",
           "rhel.activationKeys",
           "rhel.registerSystems",
           "rhel.stalenessAndDeletion"

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -308,7 +308,24 @@
             "title": "Advisor",
             "subtitle": "Red Hat Insights for Ansible",
             "icon": "AnsibleIcon",
-            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security.",
+            "alt_title": [
+              "Rules",
+              "recommendations",
+              "Configuration",
+              "security",
+              "stability",
+              "performance",
+              "advisor",
+              "incidents",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "title": "Drift",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -221,7 +221,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/drift",
@@ -304,7 +325,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/vulnerability/cves",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -263,7 +263,32 @@
             "icon": "OpenShiftIcon",
             "title": "Advisor",
             "subtitle": "Red Hat Insights for OpenShift",
-            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security.",
+            "alt_title": [
+              "Insights Advisor",
+              "OpenShift Advisor",
+              "Advisor",
+              "advisor",
+              "Recommendations",
+              "Proactive support",
+              "Proactive support",
+              "risk",
+              "support",
+              "update",
+              "update risk",
+              "update",
+              "issues",
+              "remediation",
+              "cluster state",
+              "recommendation",
+              "cluster health",
+              "remote health",
+              "proactive",
+              "support",
+              "fix",
+              "problem",
+              "issue"
+            ]
           },
           {
             "href": "/openshift/insights/vulnerability/cves",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -176,12 +176,8 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.inventory",
-          {
-            "title": "Inventory Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon",
-            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
-          }
+          "rhel.groups"
+
         ]
       },
       {

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -215,12 +215,7 @@
         "links": [
           "rhel.advisories",
           "rhel.repositories",
-          {
-            "href": "/insights/patch/systems",
-            "title": "Patch",
-            "icon": "InsightsIcon",
-            "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems."
-          },
+          "rhel.patchSystems",
           {
             "href": "/insights/advisor/recommendations",
             "title": "Advisor",

--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -117,7 +117,20 @@
               "appId": "patch",
               "title": "Systems",
               "href": "/insights/patch/systems",
-              "product": "Red Hat Insights"
+              "product": "Red Hat Insights",
+              "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
+              "alt_title": [
+                "Patch",
+                "content",
+                "advisories",
+                "insights",
+                "Rhel",
+                "patch",
+                "updates",
+                "update",
+                "systems",
+                "upgrade"
+              ]
             },
             {
               "id": "patchTemplates",

--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -70,7 +70,30 @@
           "href": "/insights/patch/packages",
           "icon": "InsightsIcon",
           "product": "Red Hat Insights",
-          "subtitle": "Red Hat Insights for RHEL"
+          "subtitle": "Red Hat Insights for RHEL",
+          "description": "Review package applicability on your Red Hat Enterprise Linux systems.",
+          "alt_title": [
+            "Packages",
+            "updates",
+            "insights",
+            "repositories",
+            "rpm",
+            "dnf",
+            "yum",
+            "errata",
+            "Errata",
+            "patch",
+            "advisories",
+            "patching",
+            "templates",
+            "content management",
+            "content view",
+            "patch cycle",
+            "satellite",
+            "RHSA",
+            "RHBA",
+            "RHEA"
+          ]
         },
         {
           "id": "repositories",

--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -437,7 +437,19 @@
             "CentOS",
             "centos",
             "Centos",
-            "centOS"
+            "centOS",
+            "upgrade",
+            "update",
+            "insights",
+            "automation",
+            "leapp",
+            "migrate",
+            "version",
+            "9.0",
+            "8.0",
+            "convert",
+            "conversion",
+            "migration"
           ]
         }
       ]

--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -51,6 +51,7 @@
           "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
           "alt_title": [
             "Errata",
+            "errata",
             "patch",
             "updates",
             "insights"
@@ -268,6 +269,7 @@
             "critical",
             "security rule",
             "errata",
+            "Errata",
             "affected but not vulnerable",
             "severity", 
             "CVE-"

--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -209,10 +209,24 @@
           "id": "policies",
           "appId": "policies",
           "title": "Policies",
-          "href": "/insights/policies/policies/list",
+          "href": "/insights/policies",
           "icon": "InsightsIcon",
           "subtitle": "Red Hat Insights for RHEL",
-          "description": "Monitor your RHEL hosts against set parameters to detect deviation or misalignment."
+          "description": "Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.",
+          "alt_title":[
+            "policies",
+            "facts",
+            "conditions",
+            "trigger", "notifications",
+            "alerts",
+            "insights",
+            "notify",
+            "integration",
+            "conditions",
+            "alerts",
+            "events",
+            "raise alerts on system configuration changes"
+          ]
         }
       ]
     },

--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -308,7 +308,6 @@
               "product": "Red Hat Insights",
               "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
               "alt_title": [
-                "Compliance",
                 "security",
                 "policies",
                 "SCAP",

--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -32,7 +32,13 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
+          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
+          "alt_title": [
+            "group",
+            "groups",
+            "Group",
+            "Groups"
+          ]          
         }
       ]
     },

--- a/static/stable/itless/services/services.json
+++ b/static/stable/itless/services/services.json
@@ -54,7 +54,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/drift",
@@ -84,7 +105,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/vulnerability/cves",

--- a/static/stable/itless/services/services.json
+++ b/static/stable/itless/services/services.json
@@ -98,13 +98,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          {
-            "href": "/insights/compliance/reports",
-            "icon": "InsightsIcon",
-            "title": "Compliance",
-            "subtitle":"Red Hat Insights for RHEL",
-            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards."
-          },
+          "rhel.complianceReports",
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/stable/itless/services/services.json
+++ b/static/stable/itless/services/services.json
@@ -48,12 +48,7 @@
         "links": [
           "rhel.advisories",
           "rhel.repositories",
-          {
-            "href": "/insights/patch/systems",
-            "title": "Patch",
-            "icon": "InsightsIcon",
-            "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems."
-          },
+          "rhel.patchSystems",
           {
             "href": "/insights/advisor/recommendations",
             "title": "Advisor",

--- a/static/stable/itless/services/services.json
+++ b/static/stable/itless/services/services.json
@@ -24,12 +24,7 @@
         "title": "Red Hat Enterprise Linux",
         "links": [
           "rhel.inventory",
-          {
-            "title": "Inventory Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon",
-            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
-          }
+          "rhel.groups"
         ]
       },
       {

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -568,7 +568,13 @@
       "icon": "InsightsIcon",
       "product": "Red Hat Insights",
       "subtitle": "Red Hat Insights for RHEL",
-      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
+      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console.",
+      "alt_title": [
+        "register rhel",
+        "Register RHEL",
+        "rhel",
+        "RHEL"
+      ]    
     },
     {
       "id": "learningResources",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -179,7 +179,30 @@
           "href": "/insights/patch/packages",
           "icon": "InsightsIcon",
           "product": "Red Hat Insights",
-          "subtitle": "Red Hat Insights for RHEL"
+          "subtitle": "Red Hat Insights for RHEL",
+          "description": "Review package applicability on your Red Hat Enterprise Linux systems.",
+          "alt_title": [
+            "Packages",
+            "updates",
+            "insights",
+            "repositories",
+            "rpm",
+            "dnf",
+            "yum",
+            "errata",
+            "Errata",
+            "patch",
+            "advisories",
+            "patching",
+            "templates",
+            "content management",
+            "content view",
+            "patch cycle",
+            "satellite",
+            "RHSA",
+            "RHBA",
+            "RHEA"
+          ]
         },
         {
           "id": "repositories",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -159,6 +159,7 @@
           "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
           "alt_title": [
             "Errata",
+            "errata",
             "patch",
             "updates",
             "insights"
@@ -376,6 +377,7 @@
             "critical",
             "security rule",
             "errata",
+            "Errata",
             "affected but not vulnerable",
             "severity", 
             "CVE-"

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -417,7 +417,6 @@
               "product": "Red Hat Insights",
               "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
               "alt_title": [
-                "Compliance",
                 "security",
                 "policies",
                 "SCAP",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -99,6 +99,7 @@
               "description": "Configure your systems to execute Ansible Playbooks.",
               "alt_title": [
                 "Remote host configuration",
+                "remote host configuration",
                 "connect systems",
                 "connection options",
                 "connect settings",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -32,7 +32,13 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
+          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
+          "alt_title": [
+            "group",
+            "groups",
+            "Group",
+            "Groups"
+          ]          
         },
         {
           "id": "imageBuilder",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -226,7 +226,20 @@
               "appId": "patch",
               "title": "Systems",
               "href": "/insights/patch/systems",
-              "product": "Red Hat Insights"
+              "product": "Red Hat Insights",
+              "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
+              "alt_title": [
+                "Patch",
+                "content",
+                "advisories",
+                "insights",
+                "Rhel",
+                "patch",
+                "updates",
+                "update",
+                "systems",
+                "upgrade"
+              ]
             },
             {
               "id": "patchTemplates",

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -318,10 +318,24 @@
           "id": "policies",
           "appId": "policies",
           "title": "Policies",
-          "href": "/insights/policies/policies/list",
+          "href": "/insights/policies",
           "icon": "InsightsIcon",
           "subtitle": "Red Hat Insights for RHEL",
-          "description": "Monitor your RHEL hosts against set parameters to detect deviation or misalignment."
+          "description": "Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.",
+          "alt_title":[
+            "policies",
+            "facts",
+            "conditions",
+            "trigger", "notifications",
+            "alerts",
+            "insights",
+            "notify",
+            "integration",
+            "conditions",
+            "alerts",
+            "events",
+            "raise alerts on system configuration changes"
+          ]
         }
       ]
     },

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -554,7 +554,19 @@
             "CentOS",
             "centos",
             "Centos",
-            "centOS"
+            "centOS",
+            "upgrade",
+            "update",
+            "insights",
+            "automation",
+            "leapp",
+            "migrate",
+            "version",
+            "9.0",
+            "8.0",
+            "convert",
+            "conversion",
+            "migration"
           ]
         }
       ]

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -449,13 +449,7 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "href": "/insights/connector",
-            "title": "Remote Host Configuration (RHC)",
-            "icon": "InsightsIcon",
-            "subtitle": "Red Hat Insights for RHEL",
-            "description": "Configure your systems to execute Ansible Playbooks."
-          },
+          "rhel.rhc",
           "rhel.activationKeys",
           "rhel.registerSystems",
           "rhel.stalenessAndDeletion"

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -319,7 +319,24 @@
             "title": "Advisor",
             "subtitle": "Red Hat Insights for Ansible",
             "icon": "AnsibleIcon",
-            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security.",
+            "alt_title": [
+              "Rules",
+              "recommendations",
+              "Configuration",
+              "security",
+              "stability",
+              "performance",
+              "advisor",
+              "incidents",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "title": "Drift",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -317,13 +317,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          {
-            "href": "/insights/compliance/reports",
-            "icon": "InsightsIcon",
-            "title": "Compliance",
-            "subtitle":"Red Hat Insights for RHEL",
-            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards."
-          },
+          "rhel.complianceReports",
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -274,7 +274,32 @@
             "icon": "OpenShiftIcon",
             "title": "Advisor",
             "subtitle": "Red Hat Insights for OpenShift",
-            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security.",
+            "alt_title": [
+              "Insights Advisor",
+              "OpenShift Advisor",
+              "Advisor",
+              "advisor",
+              "Recommendations",
+              "Proactive support",
+              "Proactive support",
+              "risk",
+              "support",
+              "update",
+              "update risk",
+              "update",
+              "issues",
+              "remediation",
+              "cluster state",
+              "recommendation",
+              "cluster health",
+              "remote health",
+              "proactive",
+              "support",
+              "fix",
+              "problem",
+              "issue"
+            ]
           },
           {
             "href": "/openshift/insights/vulnerability/cves",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -226,12 +226,7 @@
         "links": [
           "rhel.advisories",
           "rhel.repositories",
-          {
-            "href": "/insights/patch/systems",
-            "title": "Patch",
-            "icon": "InsightsIcon",
-            "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems."
-          },
+          "rhel.patchSystems",
           {
             "href": "/insights/advisor/recommendations",
             "title": "Advisor",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -232,7 +232,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/drift",
@@ -303,7 +324,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/vulnerability/cves",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -187,12 +187,8 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.inventory",
-          {
-            "title": "Inventory Groups",
-            "href": "/insights/inventory/groups",
-            "icon": "InsightsIcon",
-            "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
-          }
+          "rhel.groups"
+
         ]
       },
       {

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -159,6 +159,7 @@
           "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
           "alt_title": [
             "Errata",
+            "errata",
             "patch",
             "updates",
             "insights"
@@ -392,6 +393,7 @@
             "critical",
             "security rule",
             "errata",
+            "Errata",
             "affected but not vulnerable",
             "severity", 
             "CVE-"

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -32,7 +32,13 @@
           "title": "Groups",
           "href": "/insights/inventory/groups",
           "product": "Red Hat Insights",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."          
+          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
+          "alt_title": [
+            "group",
+            "groups",
+            "Group",
+            "Groups"
+          ]          
         },
         {
           "id": "imageBuilder",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -242,7 +242,20 @@
               "appId": "patch",
               "title": "Systems",
               "href": "/insights/patch/systems",
-              "product": "Red Hat Insights"
+              "product": "Red Hat Insights",
+              "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems.",
+              "alt_title": [
+                "Patch",
+                "content",
+                "advisories",
+                "insights",
+                "Rhel",
+                "patch",
+                "updates",
+                "update",
+                "systems",
+                "upgrade"
+              ]
             },
             {
               "id": "patchTemplates",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -179,7 +179,30 @@
           "href": "/insights/patch/packages",
           "icon": "InsightsIcon",
           "product": "Red Hat Insights",
-          "subtitle": "Red Hat Insights for RHEL"
+          "subtitle": "Red Hat Insights for RHEL",
+          "description": "Review package applicability on your Red Hat Enterprise Linux systems.",
+          "alt_title": [
+            "Packages",
+            "updates",
+            "insights",
+            "repositories",
+            "rpm",
+            "dnf",
+            "yum",
+            "errata",
+            "Errata",
+            "patch",
+            "advisories",
+            "patching",
+            "templates",
+            "content management",
+            "content view",
+            "patch cycle",
+            "satellite",
+            "RHSA",
+            "RHBA",
+            "RHEA"
+          ]
         },
         {
           "id": "repositories",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -433,7 +433,6 @@
               "product": "Red Hat Insights",
               "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
               "alt_title": [
-                "Compliance",
                 "security",
                 "policies",
                 "SCAP",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -584,7 +584,13 @@
       "icon": "InsightsIcon",
       "product": "Red Hat Insights",
       "subtitle": "Red Hat Insights for RHEL",
-      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
+      "description": "Register your systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console.",
+      "alt_title": [
+        "register rhel",
+        "Register RHEL",
+        "rhel",
+        "RHEL"
+      ]    
     },
     {
       "id": "learningResources",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -570,7 +570,19 @@
             "CentOS",
             "centos",
             "Centos",
-            "centOS"
+            "centOS",
+            "upgrade",
+            "update",
+            "insights",
+            "automation",
+            "leapp",
+            "migrate",
+            "version",
+            "9.0",
+            "8.0",
+            "convert",
+            "conversion",
+            "migration"
           ]
         }
       ]

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -99,6 +99,7 @@
               "description": "Configure your systems to execute Ansible Playbooks.",
               "alt_title": [
                 "Remote host configuration",
+                "remote host configuration",
                 "connect systems",
                 "connection options",
                 "connect settings",

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -334,10 +334,24 @@
           "id": "policies",
           "appId": "policies",
           "title": "Policies",
-          "href": "/insights/policies/policies/list",
+          "href": "/insights/policies",
           "icon": "InsightsIcon",
           "subtitle": "Red Hat Insights for RHEL",
-          "description": "Monitor your RHEL hosts against set parameters to detect deviation or misalignment."
+          "description": "Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.",
+          "alt_title":[
+            "policies",
+            "facts",
+            "conditions",
+            "trigger", "notifications",
+            "alerts",
+            "insights",
+            "notify",
+            "integration",
+            "conditions",
+            "alerts",
+            "events",
+            "raise alerts on system configuration changes"
+          ]
         }
       ]
     },

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -176,12 +176,7 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.inventory",
-        {
-          "title": "Inventory Groups",
-          "href": "/insights/inventory/groups",
-          "icon": "InsightsIcon",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access."
-        }
+          "rhel.groups"
         ]
       },
       {

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -220,7 +220,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/drift",
@@ -303,7 +324,28 @@
             "title": "Advisor",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Red Hat Enterprise Linux systems' availability, performance, and security.",
+            "alt_title": [
+              "advisor",
+              "Rules",
+              "rules",
+              "rule",
+              "Rule",
+              "insights",
+              "security",
+              "stability",
+              "performance",
+              "incidents",
+              "recommendations",
+              "configuration",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "href": "/insights/vulnerability/cves",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -307,7 +307,24 @@
             "title": "Advisor",
             "subtitle": "Red Hat Insights for Ansible",
             "icon": "AnsibleIcon",
-            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your Ansible hosts’ availability, performance, and security.",
+            "alt_title": [
+              "Rules",
+              "recommendations",
+              "Configuration",
+              "security",
+              "stability",
+              "performance",
+              "advisor",
+              "incidents",
+              "pathways",
+              "critical",
+              "upgrade",
+              "upgrade risk",
+              "incident",
+              "recommendation",
+              "pathway"
+            ]
           },
           {
             "title": "Drift",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -214,12 +214,7 @@
         "links": [
           "rhel.advisories",
           "rhel.repositories",
-          {
-            "href": "/insights/patch/systems",
-            "title": "Patch",
-            "icon": "InsightsIcon",
-            "description": "View applicable advisories and updates for your Red Hat Enterprise Linux systems."
-          },
+          "rhel.patchSystems",
           {
             "href": "/insights/advisor/recommendations",
             "title": "Advisor",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -317,13 +317,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          {
-            "href": "/insights/compliance/reports",
-            "icon": "InsightsIcon",
-            "title": "Compliance",
-            "subtitle":"Red Hat Insights for RHEL",
-            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards."
-          },
+          "rhel.complianceReports",
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -440,13 +440,7 @@
         "isGroup": true,
         "title": "Red Hat Enterprise Linux",
         "links": [
-          {
-            "href": "/insights/connector",
-            "title": "Remote Host Configuration (RHC)",
-            "icon": "InsightsIcon",
-            "subtitle": "Red Hat Insights for RHEL",
-            "description": "Configure your systems to execute Ansible Playbooks."
-          },
+          "rhel.rhc",
           "rhel.activationKeys",
           "rhel.registerSystems",
           "rhel.stalenessAndDeletion"

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -262,7 +262,32 @@
             "icon": "OpenShiftIcon",
             "title": "Advisor",
             "subtitle": "Red Hat Insights for OpenShift",
-            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security."
+            "description": "See targeted recommendations to optimize your OpenShift clusters’ availability, performance, and security.",
+            "alt_title": [
+              "Insights Advisor",
+              "OpenShift Advisor",
+              "Advisor",
+              "advisor",
+              "Recommendations",
+              "Proactive support",
+              "Proactive support",
+              "risk",
+              "support",
+              "update",
+              "update risk",
+              "update",
+              "issues",
+              "remediation",
+              "cluster state",
+              "recommendation",
+              "cluster health",
+              "remote health",
+              "proactive",
+              "support",
+              "fix",
+              "problem",
+              "issue"
+            ]
           },
           {
             "href": "/openshift/insights/vulnerability/cves",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-7102.

This fixes the issues for Insights entries listed in the ticket above. The main goal is to identify unnecessary duplicates in static-services-entries.json and make sure the search index is properly using the references from services.json. There should be no changes to navigation or "Services" section titles and hierarchy.