### PR TITLE
fix subscriptions widget visibility functions

### DIFF
--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -273,6 +273,7 @@ type WidgetPermissionMethods string
 const (
 	OrgAdmin WidgetPermissionMethods = "isOrgAdmin"
 	FeatureFlag WidgetPermissionMethods = "featureFlag"
+	HasPermissions WidgetPermissionMethods = "hasPermissions"
 )
 
 type WidgetPermission struct {

--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -272,6 +272,7 @@ type WidgetPermissionMethods string
 
 const (
 	OrgAdmin WidgetPermissionMethods = "isOrgAdmin"
+	FeatureFlag WidgetPermissionMethods = "featureFlag"
 )
 
 type WidgetPermission struct {

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	"github.com/RedHatInsights/chrome-service-backend/rest/database"
-	"github.com/RedHatInsights/chrome-service-backend/rest/featureflags"
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
 	"github.com/RedHatInsights/chrome-service-backend/rest/util"
 	"gorm.io/datatypes"
@@ -174,12 +173,7 @@ var (
 				Title: "My support cases",
 			},
 		},
-	}
-)
-
-func init() {
-	if featureflags.IsEnabled("chrome-service.subscriptions-widget.enabled") {
-		WidgetMapping[models.Subscriptions] = models.ModuleFederationMetadata{
+		models.Subscriptions: models.ModuleFederationMetadata{
 			Scope:    "subscriptionInventory",
 			Module:   "./SubscriptionsWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 4, 3, 5, 1),
@@ -190,10 +184,19 @@ func init() {
 				},
 				Icon:  models.CreditCardIcon,
 				Title: "Subscriptions",
+				Permissions: []models.WidgetPermission{
+					models.WidgetPermission{
+						Method: models.FeatureFlag,
+						Args: []any{
+							"chrome-service.subscriptions-widget.enabled",
+							true,
+						},
+					},
+				},
 			},
-		}
+		},
 	}
-}
+)
 
 func ForkBaseTemplate(userId uint, dashboard models.AvailableTemplates) (models.DashboardTemplate, error) {
 	err := dashboard.IsValid()

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -192,6 +192,12 @@ var (
 							true,
 						},
 					},
+					models.WidgetPermission{
+						Method: models.HasPermissions,
+						Args: []any{
+							"subscriptions:products:read",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
- Uses the visibility function support added by https://github.com/RedHatInsights/widget-layout/pull/69
- Hides Subscriptions widget behind feature flag `chrome-service.subscriptions-widget.enabled`
- Also hides it for users without `subscriptions:products:read` permissions.