### PR TITLE
fix: Fix Compliance entry title in All services

### DIFF
--- a/static/beta/itless/services/services.json
+++ b/static/beta/itless/services/services.json
@@ -135,7 +135,33 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          "rhel.complianceReports",
+          {
+            "href": "/insights/compliance/reports",
+            "icon": "InsightsIcon",
+            "title": "Compliance",
+            "subtitle":"Red Hat Insights for RHEL",
+            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
+            "alt_title": [
+              "security",
+              "policies",
+              "SCAP",
+              "policy",
+              "insights",
+              "regulatory",
+              "regulations",
+              "OpenSCAP",
+              "PCI",
+              "HIPAA",
+              "DSS",
+              "CSI",
+              "C2S",
+              "rules",
+              "DISA STIG",
+              "PCI-DSS",
+              "NIST",
+              "OSPP"
+            ]
+          },
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -399,7 +399,33 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          "rhel.complianceReports",
+          {
+            "href": "/insights/compliance/reports",
+            "icon": "InsightsIcon",
+            "title": "Compliance",
+            "subtitle":"Red Hat Insights for RHEL",
+            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
+            "alt_title": [
+              "security",
+              "policies",
+              "SCAP",
+              "policy",
+              "insights",
+              "regulatory",
+              "regulations",
+              "OpenSCAP",
+              "PCI",
+              "HIPAA",
+              "DSS",
+              "CSI",
+              "C2S",
+              "rules",
+              "DISA STIG",
+              "PCI-DSS",
+              "NIST",
+              "OSPP"
+            ]
+          },
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -399,7 +399,33 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          "rhel.complianceReports",
+          {
+            "href": "/insights/compliance/reports",
+            "icon": "InsightsIcon",
+            "title": "Compliance",
+            "subtitle":"Red Hat Insights for RHEL",
+            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
+            "alt_title": [
+              "security",
+              "policies",
+              "SCAP",
+              "policy",
+              "insights",
+              "regulatory",
+              "regulations",
+              "OpenSCAP",
+              "PCI",
+              "HIPAA",
+              "DSS",
+              "CSI",
+              "C2S",
+              "rules",
+              "DISA STIG",
+              "PCI-DSS",
+              "NIST",
+              "OSPP"
+            ]
+          },
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/stable/itless/services/services.json
+++ b/static/stable/itless/services/services.json
@@ -135,7 +135,33 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          "rhel.complianceReports",
+          {
+            "href": "/insights/compliance/reports",
+            "icon": "InsightsIcon",
+            "title": "Compliance",
+            "subtitle":"Red Hat Insights for RHEL",
+            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
+            "alt_title": [
+              "security",
+              "policies",
+              "SCAP",
+              "policy",
+              "insights",
+              "regulatory",
+              "regulations",
+              "OpenSCAP",
+              "PCI",
+              "HIPAA",
+              "DSS",
+              "CSI",
+              "C2S",
+              "rules",
+              "DISA STIG",
+              "PCI-DSS",
+              "NIST",
+              "OSPP"
+            ]
+          },
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -398,7 +398,33 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          "rhel.complianceReports",
+          {
+            "href": "/insights/compliance/reports",
+            "icon": "InsightsIcon",
+            "title": "Compliance",
+            "subtitle":"Red Hat Insights for RHEL",
+            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
+            "alt_title": [
+              "security",
+              "policies",
+              "SCAP",
+              "policy",
+              "insights",
+              "regulatory",
+              "regulations",
+              "OpenSCAP",
+              "PCI",
+              "HIPAA",
+              "DSS",
+              "CSI",
+              "C2S",
+              "rules",
+              "DISA STIG",
+              "PCI-DSS",
+              "NIST",
+              "OSPP"
+            ]
+          },
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -398,7 +398,33 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
-          "rhel.complianceReports",
+          {
+            "href": "/insights/compliance/reports",
+            "icon": "InsightsIcon",
+            "title": "Compliance",
+            "subtitle":"Red Hat Insights for RHEL",
+            "description": "Evaluate your Red Hat Enterprise systems’ compliance with security or regulatory standards.",
+            "alt_title": [
+              "security",
+              "policies",
+              "SCAP",
+              "policy",
+              "insights",
+              "regulatory",
+              "regulations",
+              "OpenSCAP",
+              "PCI",
+              "HIPAA",
+              "DSS",
+              "CSI",
+              "C2S",
+              "rules",
+              "DISA STIG",
+              "PCI-DSS",
+              "NIST",
+              "OSPP"
+            ]
+          },
           {
             "href": "/insights/malware/signatures",
             "title": "Malware",


### PR DESCRIPTION
This reverts recent updates to the Compliance entry in All services menu. The title must be "Compliance", not "Reports", and this is why we can't reuse a link from rhel-navigation.json.