### PR TITLE
Fix Subscriptions Widget permissions

### DIFF
--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -195,7 +195,7 @@ var (
 					models.WidgetPermission{
 						Method: models.HasPermissions,
 						Args: []any{
-							"subscriptions:products:read",
+							[]string{"subscriptions:products:read"},
 						},
 					},
 				},


### PR DESCRIPTION
[RHCLOUD-32584](https://issues.redhat.com/browse/RHCLOUD-32584)
- fixed an issue with how the required role was being passed to the `hasPermissions` method of the Subscriptions widget. This caused the permission check to always fail.