### PR TITLE
Remove view all learning resources link from learning resources widget header

### DIFF
--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -141,10 +141,6 @@ var (
 			Module:   "./BookmarkedLearningResourcesWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
 			Config: models.WidgetConfiguration{
-				HeaderLink: models.WidgetHeaderLink{
-					Title: "View all learning resources",
-					Href:  "/settings/learning-resources#documentation",
-				},
 				Icon:  models.OutlinedBookmarkIcon,
 				Title: "Bookmarked learning resources",
 			},


### PR DESCRIPTION
### Description

Because we don't have global learning resrouces page available yet, let's remove the link that takes user to settings learning resources bundle.