### PR TITLE
correct AI/ML icon

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -2,7 +2,7 @@
   {
     "id": "ai",
     "title": "AI/ML",
-    "icon": "AITechnologyIcon",
+    "icon": "BrainIcon",
     "description": "Create, train, and serve artificial intelligence and machine learning (AI/ML) models.",
     "links": [
       {

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -2,7 +2,7 @@
   {
     "id": "ai",
     "title": "AI/ML",
-    "icon": "AITechnologyIcon",
+    "icon": "BrainIcon",
     "description": "Create, train, and serve artificial intelligence and machine learning (AI/ML) models.",
     "links": [
       {

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -2,7 +2,7 @@
   {
     "id": "ai",
     "title": "AI/ML",
-    "icon": "AITechnologyIcon",
+    "icon": "BrainIcon",
     "description": "Create, train, and serve artificial intelligence and machine learning (AI/ML) models.",
     "links": [
       {

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -2,7 +2,7 @@
   {
     "id": "ai",
     "title": "AI/ML",
-    "icon": "AITechnologyIcon",
+    "icon": "BrainIcon",
     "description": "Create, train, and serve artificial intelligence and machine learning (AI/ML) models.",
     "links": [
       {


### PR DESCRIPTION
fixes [RHCLOUD-32731](https://issues.redhat.com/browse/RHCLOUD-32731). Adds the correct brain icon for AI/ML section on AllServices page

![image](https://github.com/RedHatInsights/chrome-service-backend/assets/16109803/017f1619-ac22-4e21-81ce-51a24128b4e7)
