### PR TITLE
Add export service to api documentation

### DIFF
--- a/static/beta/prod/main.yml
+++ b/static/beta/prod/main.yml
@@ -95,6 +95,12 @@ drift:
           - v1
         title: Historical system profiles
 
+export:
+  title: Export Service
+  api:
+    versions:
+      - v1
+
 image-builder:
   title: Image Builder
   api:

--- a/static/beta/stage/main.yml
+++ b/static/beta/stage/main.yml
@@ -96,6 +96,12 @@ edge:
       - v1
     isBeta: true
 
+export:
+  title: Export Service
+  api:
+    versions:
+      - v1
+
 idmsvc:
   title: "Directory and Domain Services"
   api:

--- a/static/stable/prod/main.yml
+++ b/static/stable/prod/main.yml
@@ -131,6 +131,12 @@ edge:
     versions:
       - v1
 
+export:
+  title: Export Service
+  api:
+    versions:
+      - v1
+
 hooks:
   title: Web Hooks Service
   api:

--- a/static/stable/stage/main.yml
+++ b/static/stable/stage/main.yml
@@ -84,6 +84,12 @@ edge:
       - v1
     isBeta: true
 
+export:
+  title: Export Service
+  api:
+    versions:
+      - v1
+
 idmsvc:
   title: "Directory and Domain Services"
   api:


### PR DESCRIPTION
Addressing [RHCLOUD-31439](https://issues.redhat.com/browse/RHCLOUD-31439) - Export service should be exposed in the 'legacy' API documentation