### PR TITLE
Update Jenkins Scanning Job to Support Docker

### DIFF
--- a/security-scan.sh
+++ b/security-scan.sh
@@ -15,5 +15,5 @@ DOCKERFILE_LOCATION="."
 # (Severity Options: negligible, low, medium, high, critical)
 FAIL_ON_SEVERITY="high"
 
-curl -sSL https://raw.githubusercontent.com/RedHatInsights/platform-security-gh-workflow/master/jenkins/security-scan.sh | \
+curl -sSL https://raw.githubusercontent.com/RedHatInsights/platform-security-gh-workflow/master/jenkins/security-scan-docker.sh | \
     sh -s "${IMAGE_NAME}" "${DOCKERFILE_LOCATION}" "${FAIL_ON_SEVERITY}"


### PR DESCRIPTION
## Overview

Updating the `security-scan.sh` Jenkins Security Scanning Job to support the use of Docker.

REF:

- PR - Adding a Docker Version of the Jenkins Scanning Job
   - https://github.com/RedHatInsights/platform-security-gh-workflow/pull/31/files