### PR TITLE
Update ROS nav to use new Unleash preview flag

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -237,7 +237,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.ros-preview", true]
+                                    "args": ["cost-management.ui.ros", true]
                                 }
                             ]
                         },


### PR DESCRIPTION
Update ROS to use new Unleash preview flag. 

The `cost-management.ui.ros` Unleash toggle will now use the `platform.chrome.ui.preview` constraint.