### PR TITLE
Update IBM nav to use new Unleash preview flag

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -271,7 +271,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.ibm-nav", true]
+                                    "args": ["cost-management.ui.ibm", true]
                                 }
                             ]
                         },

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -262,7 +262,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.ibm-nav", true]
+                                    "args": ["cost-management.ui.ibm", true]
                                 }
                             ]
                         },

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -271,7 +271,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.ibm-nav", true]
+                                    "args": ["cost-management.ui.ibm", true]
                                 }
                             ]
                         },

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -262,7 +262,7 @@
                             "permissions": [
                                 {
                                     "method": "featureFlag",
-                                    "args": ["cost-management.ui.ibm-nav", true]
+                                    "args": ["cost-management.ui.ibm", true]
                                 }
                             ]
                         },


### PR DESCRIPTION
Update IBM to use new Unleash preview flag. 

The `cost-management.ui.ibm` Unleash toggle will now use the `platform.chrome.ui.preview` constraint.