### PR TITLE
Use quay instead of docker registry.

### DIFF
--- a/cmd/kafka/testMessage.go
+++ b/cmd/kafka/testMessage.go
@@ -26,7 +26,7 @@ func main() {
 	id := uuid.New()
 	body := fmt.Sprintf(`{
 		"specversion": "1.0.2",
-		"type": "notifications.drawer",
+		"type": "com.redhat.console.notifications.drawer",
 		"source": "https://whatever.service.com",
 		"id": "test-message",
 		"time": "2023-05-23T11:54:03.879689005+02:00",
@@ -37,8 +37,8 @@ func main() {
 			"usernames": ["insights-qa"],
 			"payload": {
 				"id": "%s",
-				"description": "string",
-				"title": "string",
+				"description": "HOHOH",
+				"title": "string??!!",
 				"created": "2023-05-23T11:54:03.879689005+02:00",
 				"read": false,
 				"source": "string"

--- a/local/full-stack-compose.yaml
+++ b/local/full-stack-compose.yaml
@@ -2,18 +2,19 @@
 version: "3.8"
 services:
   chrome-db:
-    image: postgres:14.1-alpine
+    image: quay.io/sclorg/postgresql-15-c9s:latest
     restart: always
     environment:
-    - POSTGRES_USER=chrome
-    - POSTGRES_PASSWORD=chrome
+    - POSTGRESQL_USER=chrome
+    - POSTGRESQL_PASSWORD=chrome
+    - POSTGRESQL_DATABASE=chrome
     ports:
     - "5432:5432"
     volumes:
     - chrome-db:/var/lib/postgresql/data
 
   zoo1:
-    image: confluentinc/cp-zookeeper:7.3.2
+    image: quay.io/cloudservices/cp-zookeeper:7.2.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -24,7 +25,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888
 
   kafka1:
-    image: confluentinc/cp-kafka:7.3.2
+    image: quay.io/cloudservices/cp-kafka:7.2.1
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -49,7 +50,7 @@ services:
     - zoo1
 
   unleash_web:
-    image: unleashorg/unleash-server:latest
+    image: quay.io/cloudservices/unleash-server:latest
     ports:
     - "4242:4242"
     environment:
@@ -73,15 +74,17 @@ services:
       timeout: 1m
       retries: 5
       start_period: 15s
+  
   db:
     expose:
     - "5432"
-    image: postgres:15
+    image: quay.io/sclorg/postgresql-15-c9s:latest
     environment:
       # create a database called `db`
-      POSTGRES_DB: "db"
+      - POSTGRESQL_DATABASE=db
       # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
-      POSTGRES_HOST_AUTH_METHOD: "trust"
+      - POSTGRESQL_USER=chrome
+      - POSTGRESQL_PASSWORD=chrome
     healthcheck:
       test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
       interval: 2s

--- a/local/kafka-compose.yaml
+++ b/local/kafka-compose.yaml
@@ -2,18 +2,19 @@
 version: "3.8"
 services:
   db:
-    image: postgres:14.1-alpine
+    image: quay.io/sclorg/postgresql-15-c9s:latest
     restart: always
     environment:
-    - POSTGRES_USER=chrome
-    - POSTGRES_PASSWORD=chrome
+    - POSTGRESQL_USER=chrome
+    - POSTGRESQL_PASSWORD=chrome
+    - POSTGRESQL_DATABASE=chrome
     ports:
     - "5432:5432"
     volumes:
     - db:/var/lib/postgresql/data
 
   zoo1:
-    image: confluentinc/cp-zookeeper:7.3.2
+    image: quay.io/cloudservices/cp-zookeeper:7.2.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -24,7 +25,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888
 
   kafka1:
-    image: confluentinc/cp-kafka:7.3.2
+    image: quay.io/cloudservices/cp-kafka:7.2.1
     hostname: kafka1
     container_name: kafka1
     ports:

--- a/local/unleash-compose.yaml
+++ b/local/unleash-compose.yaml
@@ -5,7 +5,7 @@ services:
   # The Unleash server contains the Unleash configuration and
   # communicates with server-side SDKs and the Unleash Proxy
   unleash_web:
-    image: unleashorg/unleash-server:latest
+    image: quay.io/cloudservices/unleash-server:latest
     ports:
     - "4242:4242"
     environment:
@@ -29,10 +29,11 @@ services:
   db:
     expose:
     - "5432"
-    image: postgres:15
+    image: quay.io/sclorg/postgresql-15-c9s:latest
     environment:
-      POSTGRES_DB: "db"
-      POSTGRES_HOST_AUTH_METHOD: "trust"
+      - POSTGRESQL_DATABASE=db
+      - POSTGRESQL_USER=chrome
+      - POSTGRESQL_PASSWORD=chrome
     healthcheck:
       test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
       interval: 2s


### PR DESCRIPTION
Docker is rate-limiting requests. We can use the internal registry from quay.