### PR TITLE
Update generate search index script to support itless envs

### DIFF
--- a/cmd/search/publishSearchIndex.go
+++ b/cmd/search/publishSearchIndex.go
@@ -21,7 +21,8 @@ type Release string
 const (
 	Prod          SearchEnv = "prod"
 	Stage         SearchEnv = "stage"
-	Stale         Release   = "stable"
+	Itless        SearchEnv = "itless"
+	Stable        Release   = "stable"
 	Beta          Release   = "beta"
 	ssoPathname   string    = "/auth/realms/redhat-external/protocol/openid-connect/token"
 	hydraPathname string    = "/hydra/rest/search/console/index"
@@ -361,8 +362,9 @@ func injectLinks(templateData []byte, flatLinks []LinkEntry) ([]ServiceEntry, er
 
 func flattenIndexBase(indexBase []ServiceEntry, env SearchEnv) ([]ModuleIndexEntry, error) {
 	hccOrigins := EnvMap{
-		Prod:  "https://console.redhat.com",
-		Stage: "https://console.stage.redhat.com",
+		Prod:   "https://console.redhat.com",
+		Stage:  "https://console.stage.redhat.com",
+		Itless: "https://console.openshiftusgov.com",
 	}
 	bundleMapping := map[string]string{
 		"application-services": "Application Services",
@@ -633,8 +635,8 @@ func main() {
 			handleErrors(errors, dryRun)
 			return
 		}
-		writeEnvs := []SearchEnv{Prod, Stage}
-		writeReleases := []Release{Stale, Beta}
+		writeEnvs := []SearchEnv{Prod, Stage, Itless}
+		writeReleases := []Release{Stable, Beta}
 		for _, env := range writeEnvs {
 			for _, release := range writeReleases {
 				searchIndex, err := constructIndex(env, release)

--- a/static/beta/itless/navigation/iam-navigation.json
+++ b/static/beta/itless/navigation/iam-navigation.json
@@ -3,6 +3,7 @@
   "title": "Identity & Access Management",
   "navItems": [
     {
+      "id": "my-user-access",
       "appId": "rbac",
       "title": "My User Access",
       "href": "/iam/my-user-access",

--- a/static/stable/itless/navigation/iam-navigation.json
+++ b/static/stable/itless/navigation/iam-navigation.json
@@ -3,6 +3,7 @@
   "title": "Identity & Access Management",
   "navItems": [
     {
+      "id": "my-user-access",
       "appId": "rbac",
       "title": "My User Access",
       "href": "/iam/my-user-access",


### PR DESCRIPTION
There is an issue where we are seeing 404's to the new `search-index.json` file in itless envs - which causes the entire UI to fail to load. I've tested this change in our envs and everything works as anticipated (though we will eventually need to revisit for multiple search endpoint URLs). 