### PR TITLE
Add alt_titles for ACS for search

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -451,7 +451,11 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "alt_title": [
+              "acs",
+              "ACS"
+            ]
           }
         ]
       },

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -451,7 +451,11 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "alt_title": [
+              "acs",
+              "ACS"
+            ]
           }
         ]
       },

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -451,7 +451,11 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "alt_title": [
+              "acs",
+              "ACS"
+            ]
           }
         ]
       },

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -451,7 +451,11 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "alt_title": [
+              "acs",
+              "ACS"
+            ]
           }
         ]
       },


### PR DESCRIPTION
For [RHCLOUD-31917](https://issues.redhat.com/browse/RHCLOUD-31917). This is my first time working on the search stuff, but I'm assuming I don't need to copy these `alt_titles` for the `openshift-navigation.json` ACS entries as well if I understand the `search-index` README correctly