### PR TITLE
fix inventory page not loading

### DIFF
--- a/static/stable/itless/navigation/rhel-navigation.json
+++ b/static/stable/itless/navigation/rhel-navigation.json
@@ -125,7 +125,7 @@
           "id": "repositories",
           "appId": "contentSources",
           "title": "Repositories",
-          "href": "/insights/content",
+          "href": "/insights/content/repositories",
           "icon": "SubscriptionsIcon",
           "product": "Red Hat Insights",
           "subtitle": "Red Hat Insights for RHEL",


### PR DESCRIPTION
There's an issue with the insights repositories page not loading in itless environment. Ends up loading the dashboard page instead. Wonder if it has to do with the route being wrong. 