### PR TITLE
Update ACS description for boosting search

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -88,7 +88,7 @@
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
-          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
           "routes": [
             {
               "id": "clusterOverview",
@@ -96,7 +96,7 @@
               "title": "Overview",
               "href": "/openshift/acs/overview",
               "icon": "ACSIcon",
-              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS."
             },
             {
               "id": "acsGettingStarted",

--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -454,7 +454,7 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
             "alt_title": [
               "acs",
               "ACS",

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -88,7 +88,7 @@
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
-          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
           "routes": [
             {
               "id": "clusterOverview",
@@ -96,7 +96,7 @@
               "title": "Overview",
               "href": "/openshift/acs/overview",
               "icon": "ACSIcon",
-              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS."
             },
             {
               "id": "acsGettingStarted",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -454,7 +454,7 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
             "alt_title": [
               "acs",
               "ACS",

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -88,7 +88,7 @@
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
-          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
           "routes": [
             {
               "id": "clusterOverview",
@@ -96,7 +96,7 @@
               "title": "Overview",
               "href": "/openshift/acs/overview",
               "icon": "ACSIcon",
-              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS."
             },
             {
               "id": "acsGettingStarted",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -454,7 +454,7 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
             "alt_title": [
               "acs",
               "ACS",

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -88,7 +88,7 @@
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
-          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+          "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
           "routes": [
             {
               "id": "clusterOverview",
@@ -96,7 +96,7 @@
               "title": "Overview",
               "href": "/openshift/acs/overview",
               "icon": "ACSIcon",
-              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture."
+              "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS."
             },
             {
               "id": "acsGettingStarted",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -454,7 +454,7 @@
             "title": "Advanced Cluster Security",
             "href": "/openshift/acs/overview",
             "icon": "ACSIcon",
-            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.",
+            "description": "Securely build, deploy, and run your cloud applications using Kubernetes-native architecture with ACS.",
             "alt_title": [
               "acs",
               "ACS",


### PR DESCRIPTION
Adding the `alt_titles` for `acs` in https://github.com/RedHatInsights/chrome-service-backend/pull/565 did not do enough for search boosting for ACS to show up in the top 10 results. Adding `ACS` to the description here boosts it to 6/10