### PR TITLE
Fix DB users in local compose file

### DIFF
--- a/local/full-stack-compose.yaml
+++ b/local/full-stack-compose.yaml
@@ -55,7 +55,7 @@ services:
     - "4242:4242"
     environment:
       # This points Unleash to its backing database (defined in the `db` section below)
-      DATABASE_URL: "postgres://postgres:unleash@db/postgres"
+      DATABASE_URL: "postgres://chrome:chrome@db/db"
       DATABASE_SSL: "false"
       LOG_LEVEL: "warn"
       INIT_FRONTEND_API_TOKENS: "default:development.unleash-insecure-frontend-api-token"
@@ -82,11 +82,10 @@ services:
     environment:
       # create a database called `db`
       - POSTGRESQL_DATABASE=db
-      # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
       - POSTGRESQL_USER=chrome
       - POSTGRESQL_PASSWORD=chrome
     healthcheck:
-      test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
+      test: ["CMD", "pg_isready", "--username=chrome", "--host=127.0.0.1", "--port=5432"]
       interval: 2s
       timeout: 1m
       retries: 5

--- a/local/unleash-compose.yaml
+++ b/local/unleash-compose.yaml
@@ -9,7 +9,7 @@ services:
     ports:
     - "4242:4242"
     environment:
-      DATABASE_URL: "postgres://postgres:unleash@db/postgres"
+      DATABASE_URL: "postgres://chrome:chrome@db/postgres"
       DATABASE_SSL: "false"
       LOG_LEVEL: "warn"
       INIT_FRONTEND_API_TOKENS: "default:development.unleash-insecure-frontend-api-token"
@@ -35,7 +35,7 @@ services:
       - POSTGRESQL_USER=chrome
       - POSTGRESQL_PASSWORD=chrome
     healthcheck:
-      test: ["CMD", "pg_isready", "--username=postgres", "--host=127.0.0.1", "--port=5432"]
+      test: ["CMD", "pg_isready", "--username=chrome", "--host=127.0.0.1", "--port=5432"]
       interval: 2s
       timeout: 1m
       retries: 5


### PR DESCRIPTION
This appears to have broken in https://github.com/RedHatInsights/chrome-service-backend/commit/3ac5f4441c0cc11816ac458fc2bafc48350f6043, when the `trust` method of authentication for the databases was disabled, and they started actually checking passwords.