### PR TITLE
Add config for stage activation keys

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -519,7 +519,7 @@
                 "id": "activation-keys",
                 "module": "./RootApp",
                 "routes": [
-                    {"pathname": "/insights/connector/activation-keys"},
+                    {"pathname": "/insights/connector/activation-keys"}
                 ]
             }
         ]

--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -512,6 +512,18 @@
             }
         ]
     },
+    "activationKeys": {
+        "manifestLocation": "/apps/activation-keys/fed-mods.json",
+        "modules": [
+            {
+                "id": "activation-keys",
+                "module": "./RootApp",
+                "routes": [
+                    {"pathname": "/insights/connector/activation-keys"},
+                ]
+            }
+        ]
+    }
     "subscriptionInventory": {
         "manifestLocation": "/apps/subscription-inventory/fed-mods.json",
         "modules": [

--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -523,7 +523,7 @@
                 ]
             }
         ]
-    }
+    },
     "subscriptionInventory": {
         "manifestLocation": "/apps/subscription-inventory/fed-mods.json",
         "modules": [

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -138,7 +138,7 @@
             },
             {
               "id": "activationKeys",
-              "appId": "connector",
+              "appId": "activation-keys",
               "title": "Activation Keys",
               "href": "/insights/connector/activation-keys",
               "icon": "InsightsIcon",

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -458,6 +458,18 @@
         }
     ]
   },
+  "activationKeys": {
+      "manifestLocation": "/apps/activation-keys/fed-mods.json",
+      "modules": [
+          {
+              "id": "activation-keys",
+              "module": "./RootApp",
+              "routes": [
+                  {"pathname": "/insights/connector/activation-keys"},
+              ]
+          }
+      ]
+  }
   "subscriptionInventory": {
       "manifestLocation": "/apps/subscription-inventory/fed-mods.json",
       "modules": [

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -465,7 +465,7 @@
               "id": "activation-keys",
               "module": "./RootApp",
               "routes": [
-                  {"pathname": "/insights/connector/activation-keys"},
+                  {"pathname": "/insights/connector/activation-keys"}
               ]
           }
       ]

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -469,7 +469,7 @@
               ]
           }
       ]
-  }
+  },
   "subscriptionInventory": {
       "manifestLocation": "/apps/subscription-inventory/fed-mods.json",
       "modules": [

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -138,7 +138,7 @@
             },
             {
               "id": "activationKeys",
-              "appId": "connector",
+              "appId": "activation-keys",
               "title": "Activation Keys",
               "href": "/insights/connector/activation-keys",
               "icon": "InsightsIcon",


### PR DESCRIPTION
This adds the config to use activation-keys-ui's deployment instead of sed-frontend. This is part of the effort to decouple those two applications.

Navigation should not have to change I think - as the routes are staying the same. Just the location of the code is changing.