### PR TITLE
Access Management Navigation Updates (Stage)

### DIFF
--- a/static/beta/stage/navigation/iam-navigation.json
+++ b/static/beta/stage/navigation/iam-navigation.json
@@ -104,7 +104,7 @@
           "id": "overview-new",
           "appId": "rbac",
           "title": "Overview",
-          "href": "/iam/user-access/overview",
+          "href": "/iam/access-management/overview",
           "permissions": [
             {
               "method": "featureFlag",
@@ -118,14 +118,14 @@
           "appId": "rbac",
           "title": "Workspaces",
           "icon": "PlaceholderIcon",
-          "href": "/iam/user-access/workspaces",
+          "href": "/iam/access-management/workspaces",
           "product": "Identity & Access Management"
         },
         {
           "id": "usersAndUserGroups",
           "appId": "rbac",
           "title": "Users & User Groups",
-          "href": "/iam/user-access/users-and-user-groups",
+          "href": "/iam/access-management/users-and-user-groups",
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management",
           "description": "Manage your organization's role-based access control (RBAC) to services.",
@@ -151,14 +151,14 @@
           "id": "roles-new",
           "appId": "rbac",
           "title": "Roles",
-          "href": "/iam/user-access/roles",
+          "href": "/iam/access-management/roles",
           "product": "Identity & Access Management"
         },
         {
           "id": "accessRequests-new",
           "appId": "rbac",
           "title": "Red Hat Access Requests",
-          "href": "/iam/user-access/access-requests",
+          "href": "/iam/access-management/access-requests",
           "notifier": "chrome.accessRequests.hasUnseen"
         }
       ]

--- a/static/beta/stage/navigation/iam-navigation.json
+++ b/static/beta/stage/navigation/iam-navigation.json
@@ -15,11 +15,11 @@
       "permissions": [
         {
           "method": "loosePermissions",
-          "args": [
-            [
-              "rbac:*:*"
-            ]
-          ]
+          "args": [["rbac:*:*"]]
+        },
+        {
+          "method": "featureFlag",
+          "args": ["platform.rbac.workspaces", false]
         }
       ],
       "routes": [
@@ -79,6 +79,83 @@
         },
         {
           "id": "accessRequests",
+          "appId": "rbac",
+          "title": "Red Hat Access Requests",
+          "href": "/iam/user-access/access-requests",
+          "notifier": "chrome.accessRequests.hasUnseen"
+        }
+      ]
+    },
+    {
+      "title": "Access Management",
+      "expandable": true,
+      "permissions": [
+        {
+          "method": "loosePermissions",
+          "args": [["rbac:*:*"]]
+        },
+        {
+          "method": "featureFlag",
+          "args": ["platform.rbac.workspaces", true]
+        }
+      ],
+      "routes": [
+        {
+          "id": "overview-new",
+          "appId": "rbac",
+          "title": "Overview",
+          "href": "/iam/user-access/overview",
+          "permissions": [
+            {
+              "method": "featureFlag",
+              "args": ["platform.rbac.overview", true]
+            }
+          ],
+          "product": "Identity & Access Management"
+        },
+        {
+          "id": "workspaces",
+          "appId": "rbac",
+          "title": "Workspaces",
+          "icon": "PlaceholderIcon",
+          "href": "/iam/user-access/workspaces",
+          "product": "Identity & Access Management"
+        },
+        {
+          "id": "usersAndUserGroups",
+          "appId": "rbac",
+          "title": "Users & User Groups",
+          "href": "/iam/user-access/users-and-user-groups",
+          "icon": "PlaceholderIcon",
+          "product": "Identity & Access Management",
+          "description": "Manage your organization's role-based access control (RBAC) to services.",
+          "alt_title": [
+            "role based access management",
+            "user management",
+            "user access",
+            "identity management",
+            "users",
+            "roles",
+            "groups",
+            "permissions",
+            "access",
+            "admin",
+            "administrator",
+            "editor",
+            "authorization",
+            "viewer",
+            "rbac"
+          ]
+        },
+        {
+          "id": "roles-new",
+          "appId": "rbac",
+          "title": "Roles",
+          "href": "/iam/user-access/roles",
+          "product": "Identity & Access Management"
+        },
+        {
+          "id": "accessRequests-new",
           "appId": "rbac",
           "title": "Red Hat Access Requests",
           "href": "/iam/user-access/access-requests",

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -10,16 +10,92 @@
       "description": "View your account permissions for Red Hat Hybrid Cloud Console services."
     },
     {
+      "title": "User Accesss",
+      "expandable": true,
+      "permissions": [
+        {
+          "method": "loosePermissions",
+          "args": [["rbac:*:*"]]
+        },
+        {
+          "method": "featureFlag",
+          "args": ["platform.rbac.workspaces", false]
+        }
+      ],
+      "routes": [
+        {
+          "id": "overview",
+          "appId": "rbac",
+          "title": "Overview",
+          "href": "/iam/user-access/overview",
+          "permissions": [
+            {
+              "method": "featureFlag",
+              "args": ["platform.rbac.overview", true]
+            }
+          ],
+          "product": "Identity & Access Management"
+        },
+        {
+          "id": "users",
+          "appId": "rbac",
+          "title": "Users",
+          "href": "/iam/user-access/users",
+          "icon": "PlaceholderIcon",
+          "product": "Identity & Access Management",
+          "description": "Manage your organization's role-based access control (RBAC) to services.",
+          "alt_title": [
+            "role based access management",
+            "user management",
+            "user access",
+            "identity management",
+            "users",
+            "roles",
+            "permissions",
+            "access",
+            "admin",
+            "administrator",
+            "editor",
+            "authorization",
+            "viewer",
+            "rbac"
+          ]
+        },
+        {
+          "id": "roles",
+          "appId": "rbac",
+          "title": "Roles",
+          "href": "/iam/user-access/roles",
+          "product": "Identity & Access Management"
+        },
+        {
+          "id": "groups",
+          "appId": "rbac",
+          "title": "Groups",
+          "href": "/iam/user-access/groups",
+          "icon": "PlaceholderIcon",
+          "product": "Identity & Access Management"
+        },
+        {
+          "id": "accessRequests",
+          "appId": "rbac",
+          "title": "Red Hat Access Requests",
+          "href": "/iam/user-access/access-requests",
+          "notifier": "chrome.accessRequests.hasUnseen"
+        }
+      ]
+    },
+    {
       "title": "Access Management",
       "expandable": true,
       "permissions": [
         {
           "method": "loosePermissions",
-          "args": [
-            [
-              "rbac:*:*"
-            ]
-          ]
+          "args": [["rbac:*:*"]]
+        },
+        {
+          "method": "featureFlag",
+          "args": ["platform.rbac.workspaces", true]
         }
       ],
       "routes": [

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -10,7 +10,7 @@
       "description": "View your account permissions for Red Hat Hybrid Cloud Console services."
     },
     {
-      "title": "User Access",
+      "title": "Access Management",
       "expandable": true,
       "permissions": [
         {
@@ -37,10 +37,18 @@
           "product": "Identity & Access Management"
         },
         {
-          "id": "users",
+          "id": "workspaces",
           "appId": "rbac",
-          "title": "Users",
-          "href": "/iam/user-access/users",
+          "title": "Workspaces",
+          "icon": "PlaceholderIcon",
+          "href": "/iam/user-access/workspaces",
+          "product": "Identity & Access Management"
+        },
+        {
+          "id": "usersAndUserGroups",
+          "appId": "rbac",
+          "title": "Users & User Groups",
+          "href": "/iam/user-access/users-and-user-groups",
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management",
           "description": "Manage your organization's role-based access control (RBAC) to services.",
@@ -51,6 +59,7 @@
             "identity management",
             "users",
             "roles",
+            "groups",
             "permissions",
             "access",
             "admin",
@@ -66,14 +75,6 @@
           "appId": "rbac",
           "title": "Roles",
           "href": "/iam/user-access/roles",
-          "product": "Identity & Access Management"
-        },
-        {
-          "id": "groups",
-          "appId": "rbac",
-          "title": "Groups",
-          "href": "/iam/user-access/groups",
-          "icon": "PlaceholderIcon",
           "product": "Identity & Access Management"
         },
         {

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -10,7 +10,7 @@
       "description": "View your account permissions for Red Hat Hybrid Cloud Console services."
     },
     {
-      "title": "User Accesss",
+      "title": "User Access",
       "expandable": true,
       "permissions": [
         {
@@ -147,14 +147,14 @@
           ]
         },
         {
-          "id": "roles",
+          "id": "roles-new",
           "appId": "rbac",
           "title": "Roles",
           "href": "/iam/user-access/roles",
           "product": "Identity & Access Management"
         },
         {
-          "id": "accessRequests",
+          "id": "accessRequests-new",
           "appId": "rbac",
           "title": "Red Hat Access Requests",
           "href": "/iam/user-access/access-requests",

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -103,7 +103,7 @@
           "id": "overview-new",
           "appId": "rbac",
           "title": "Overview",
-          "href": "/iam/user-access/overview",
+          "href": "/iam/access-management/overview",
           "permissions": [
             {
               "method": "featureFlag",
@@ -117,14 +117,14 @@
           "appId": "rbac",
           "title": "Workspaces",
           "icon": "PlaceholderIcon",
-          "href": "/iam/user-access/workspaces",
+          "href": "/iam/access-management/workspaces",
           "product": "Identity & Access Management"
         },
         {
           "id": "usersAndUserGroups",
           "appId": "rbac",
           "title": "Users & User Groups",
-          "href": "/iam/user-access/users-and-user-groups",
+          "href": "/iam/access-management/users-and-user-groups",
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management",
           "description": "Manage your organization's role-based access control (RBAC) to services.",
@@ -150,14 +150,14 @@
           "id": "roles-new",
           "appId": "rbac",
           "title": "Roles",
-          "href": "/iam/user-access/roles",
+          "href": "/iam/access-management/roles",
           "product": "Identity & Access Management"
         },
         {
           "id": "accessRequests-new",
           "appId": "rbac",
           "title": "Red Hat Access Requests",
-          "href": "/iam/user-access/access-requests",
+          "href": "/iam/access-management/access-requests",
           "notifier": "chrome.accessRequests.hasUnseen"
         }
       ]

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -100,7 +100,7 @@
       ],
       "routes": [
         {
-          "id": "overview",
+          "id": "overview-new",
           "appId": "rbac",
           "title": "Overview",
           "href": "/iam/user-access/overview",


### PR DESCRIPTION
## Access Management Navigation Updates [RHCLOUD-32233](https://issues.redhat.com/browse/RHCLOUD-32233)
Updated the following navigation in Stage Beta and Stable:
- [x] The “User Access” is replaced with “Access Management”. 
- [x] There is a new nav item for "Workspaces"
- [x] “Users and User Groups” replaces the individual “Users” and “Groups” pages. 
- [X] changes are hidden behind platform.rbac.workspaces feature flag

## Before
![before](https://github.com/user-attachments/assets/4ce8fa69-bd05-4040-98ff-e97f7feb9993)
## After
![after](https://github.com/user-attachments/assets/f1d6a05d-53ab-424a-a5d9-b01877480b39)
