### PR TITLE
Add endpooint to remember user preview visit.

### DIFF
--- a/rest/models/UserIdentity.go
+++ b/rest/models/UserIdentity.go
@@ -28,6 +28,7 @@ type UserIdentity struct {
 	VisitedBundles     datatypes.JSON                    `json:"visitedBundles,omitempty" gorm:"type: JSONB"`
 	DashboardTemplates []DashboardTemplate               `json:"dashboardTemplates,omitempty"`
 	UIPreview          bool                              `json:"uiPreview"`
+	UIPreviewSeen      bool                              `json:"uiPreviewSeen"`
 }
 
 type UserIdentityResponse struct {
@@ -41,4 +42,5 @@ type UserIdentityResponse struct {
 	SelfReport       SelfReport     `json:"selfReport"`
 	VisitedBundles   datatypes.JSON `json:"visitedBundles,omitempty" gorm:"type: JSONB"`
 	UIPreview        bool           `json:"uiPreview"`
+	UIPreviewSeen    bool           `json:"uiPreviewSeen"`
 }

--- a/rest/routes/identity.go
+++ b/rest/routes/identity.go
@@ -51,6 +51,7 @@ func GetUserIdentity(w http.ResponseWriter, r *http.Request) {
 		SelfReport:       updatedUser.SelfReport,
 		VisitedBundles:   updatedUser.VisitedBundles,
 		UIPreview:        updatedUser.UIPreview,
+		UIPreviewSeen:    updatedUser.UIPreviewSeen,
 	}
 
 	resp := util.EntityResponse[models.UserIdentityResponse]{
@@ -140,10 +141,25 @@ func UpdateUserPreview(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+func MarkPreviewSeen(w http.ResponseWriter, r *http.Request) {
+	user := r.Context().Value(util.USER_CTX_KEY).(models.UserIdentity)
+	err := service.MarkPreviewSeen(&user)
+	if err != nil {
+		handleIdentityError(err, w)
+		return
+	}
+
+	resp := util.EntityResponse[models.UserIdentity]{
+		Data: user,
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
 func MakeUserIdentityRoutes(sub chi.Router) {
 	sub.Get("/", GetUserIdentity)
 	sub.Get("/intercom", GetIntercomHash)
 	sub.Post("/update-ui-preview", UpdateUserPreview)
+	sub.Post("/mark-preview-seen", MarkPreviewSeen)
 	sub.Route("/visited-bundles", func(r chi.Router) {
 		r.Post("/", AddVisitedBundle)
 		r.Get("/", GetVisitedBundles)

--- a/rest/service/identity.go
+++ b/rest/service/identity.go
@@ -189,3 +189,7 @@ func UpdateUserPreview(identity *models.UserIdentity, preview bool) error {
 	identity.UIPreview = preview
 	return database.DB.Model(identity).Update("ui_preview", preview).Error
 }
+
+func MarkPreviewSeen(identity *models.UserIdentity) error {
+	return database.DB.Model(identity).Updates(models.UserIdentity{UIPreviewSeen: true}).Error
+}


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-34323

It enables remembering if a user visited the preview environment.