### PR TITLE
fix: Remove Groups entry from stage/stable navigation

### DIFF
--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -27,20 +27,6 @@
           "subtitle": "Red Hat Insights for RHEL"
         },
         {
-          "id": "groups",
-          "appId": "inventory",
-          "title": "Groups",
-          "href": "/insights/inventory/groups",
-          "product": "Red Hat Insights",
-          "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
-          "alt_title": [
-            "group",
-            "groups",
-            "Group",
-            "Groups"
-          ]
-        },
-        {
           "id": "workspaces",
           "appId": "inventory",
           "title": "Workspaces",
@@ -48,10 +34,8 @@
           "product": "Red Hat Insights",
           "description": "Group your Red Hat Enterprise Linux systems for more granular User Access.",
           "alt_title": [
-            "workspace",
-            "workspaces",
-            "Workspace",
-            "Workspaces"
+            "group",
+            "groups"
           ]
         },
         {

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -181,7 +181,6 @@
         "links": [
           "rhel.imageBuilder",
           "rhel.inventory",
-          "rhel.groups",
           "rhel.workspaces"
         ]
       },


### PR DESCRIPTION
Quick PR to remove the Groups entry completely from the stage stable navigation. After the recent updates, it led to a bug where both Workspaces and Groups have become visible.