### PR TITLE
Remove patch packages mountpoint.

### DIFF
--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -445,13 +445,6 @@
                 "routes": [
                     {
                         "pathname": "/insights/patch"
-                    },
-                    {
-                        "pathname": "/insights/patch/packages",
-                        "supportCaseData": {
-                            "product": "Red Hat Insights",
-                            "version": "Content Services"
-                        }
                     }
                 ]
             }

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -458,13 +458,6 @@
               "routes": [
                   {
                       "pathname": "/insights/patch"
-                  },
-                  {
-                      "pathname": "/insights/patch/packages",
-                      "supportCaseData": {
-                          "product": "Red Hat Insights",
-                          "version": "Content Services"
-                      }
                   }
               ]
           }


### PR DESCRIPTION
The routing in the patch is not setup to handle multiple mount points. Let's remove it from now and see if we can configure the support cases slightly differently.