### PR TITLE
add missing / to manifestLocation

### DIFF
--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -503,7 +503,7 @@
       ]
   },
   "subscriptionsDashboardUi": {
-    "manifestLocation": "apps/subscriptions-dashboard-ui/fed-mods.json",
+    "manifestLocation": "/apps/subscriptions-dashboard-ui/fed-mods.json",
     "modules": [
         {
             "id": "subscriptions-dashboard-ui",


### PR DESCRIPTION
In Stage stable, the [Subscriptions Overview page](https://console.stage.redhat.com/subscriptions/overview) is failing to load due to a request to `https://console.stage.redhat.comapps/subscriptions-dashboard-ui/fed-mods.json?ts=1724182759104` 

(notice `...comapps...` instead of `...com/apps...`) 