### PR TITLE
Allow configure permissions on UI module routes.

### DIFF
--- a/docs/frontend-routes.md
+++ b/docs/frontend-routes.md
@@ -1,0 +1,36 @@
+# Frontend routes
+
+Frontend routes are defined in UI module configuration files.
+
+## Routes visibility
+
+Similar to navigation items or search index entries, routes can leverage the `permissions` configuration to further restrict routes visibility on additional conditions rather than just environment. If a route permission is not met, a not found screen id displayed to the user.
+
+### Example configuration
+
+The following route will be visible only for users which have @foo.bar email. Any chrome [visibility method](https://github.com/RedHatInsights/insights-chrome/blob/master/docs/navigation.md#permissions) can be used.
+
+```JSON
+{
+  "landing": {
+    "manifestLocation": "/apps/landing/fed-mods.json",
+    "defaultDocumentTitle": "Hybrid Cloud Console Home",
+    "isFedramp": true,
+    "modules": [
+      {
+        "id": "landing",
+        "module": "./RootApp",
+        "routes": [
+          {
+            "permissions": [{
+                "method": "withEmail",
+                "args": ["@foo.bar"]
+            }],
+            "pathname": "/"
+          }
+        ]
+      }
+    ]
+  },
+}
+```

--- a/static/modulesSchema.json
+++ b/static/modulesSchema.json
@@ -2,6 +2,25 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "HCC federated modules json schema",
   "$defs": {
+    "permission": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "apps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {}
+        }
+      },
+      "additionalAttributes": false
+    },
     "supportCaseData": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Allow the same visibility configuration on routes as on nav items or search entries.