### PR TITLE
Add activation keys prod config

### DIFF
--- a/static/beta/prod/modules/fed-modules.json
+++ b/static/beta/prod/modules/fed-modules.json
@@ -390,6 +390,18 @@
             }
         ]
     },
+    "activationKeys": {
+        "manifestLocation": "/apps/activation-keys/fed-mods.json",
+        "modules": [
+            {
+                "id": "activation-keys",
+                "module": "./RootApp",
+                "routes": [
+                    {"pathname": "/insights/connector/activation-keys"}
+                ]
+            }
+        ]
+    },
     "subscriptionInventory": {
         "manifestLocation": "/apps/subscription-inventory/fed-mods.json",
         "modules": [

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -139,7 +139,7 @@
             },
             {
               "id": "activationKeys",
-              "appId": "connector",
+              "appId": "activation-keys",
               "title": "Activation keys",
               "href": "/insights/connector/activation-keys",
               "icon": "InsightsIcon",

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -489,6 +489,18 @@
             }
         ]
     },
+    "activationKeys": {
+        "manifestLocation": "/apps/activation-keys/fed-mods.json",
+        "modules": [
+            {
+                "id": "activation-keys",
+                "module": "./RootApp",
+                "routes": [
+                    {"pathname": "/insights/connector/activation-keys"}
+                ]
+            }
+        ]
+    },
     "subscriptionInventory": {
         "manifestLocation": "/apps/subscription-inventory/fed-mods.json",
         "modules": [

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -138,7 +138,7 @@
             },
             {
               "id": "activationKeys",
-              "appId": "connector",
+              "appId": "activation-keys",
               "title": "Activation Keys",
               "href": "/insights/connector/activation-keys",
               "icon": "InsightsIcon",


### PR DESCRIPTION
This adds the activation keys prod config. It is marked as a draft for now as it is dependent on RHCLOUD-34863 to have the assets added to prod akamai.