### PR TITLE
chore(RHINENG-10516): Remove staleness feature flag

### DIFF
--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -166,13 +166,7 @@
               "href": "/insights/inventory/staleness-and-deletion",
               "icon": "InsightsIcon",
               "product": "Red Hat Insights",
-              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["hbi.custom-staleness", true]
-                }
-              ]
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted."
             }
           ]
         }

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -165,13 +165,7 @@
               "href": "/insights/inventory/staleness-and-deletion",
               "icon": "InsightsIcon",
               "product": "Red Hat Insights",
-              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["hbi.custom-staleness", true]
-                }
-              ]
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted."
             }
           ]
         }

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -165,13 +165,7 @@
               "href": "/insights/inventory/staleness-and-deletion",
               "icon": "InsightsIcon",
               "product": "Red Hat Insights",
-              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["hbi.custom-staleness", true]
-                }
-              ]
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted."
             }
           ]
         }

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -137,13 +137,7 @@
               "href": "/insights/inventory/staleness-and-deletion",
               "icon": "InsightsIcon",
               "product": "Red Hat Insights",
-              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted.",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["hbi.custom-staleness", true]
-                }
-              ]
+              "description": "Configure when your systems should be marked as stale, marked as stale warning, and be deleted."
             }
           ]
         }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-10516

This removes all occurrences of the "hbi.custom-staleness" feature flag. The flag is no longer planned to switch, and the feature is considered stable in production.