### PR TITLE
add idmsvc to services directory (stage)

### DIFF
--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -94,9 +94,25 @@
             "id": "idmsvc",
             "appId": "idmsvc",
             "title": "Directory and Domain Services",
-            "description": "Directory and Domain Services for console.redhat.com",
+            "description": "Register identity and access systems to enable machines to automatically join a domain",
             "href": "/settings/idmsvc",
-            "icon": "PlaceholderIcon"
+            "icon": "PlaceholderIcon",
+            "alt_title": [
+                "directory",
+                "domain",
+                "ipa",
+                "freeipa",
+                "idm",
+                "sssd",
+                "ldap",
+                "kerberos",
+                "join",
+                "enrol",
+                "enroll",
+                "authentication",
+                "authorisation",
+                "authorization"
+            ]
         }
     ]
 }

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -150,6 +150,13 @@
           "iam.authFactors",
           "iam.serviceAccounts"
         ]
+      },
+      {
+        "isGroup": true,
+        "title": "Host Identity",
+        "links": [
+          "settings.idmsvc"
+        ]
       }
     ]
   },
@@ -164,6 +171,7 @@
         "title": "Console Settings",
         "links": [
           "settings.integrations",
+          "settings.idmsvc",
           "settings.notifications"
         ]
       }
@@ -435,7 +443,8 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify potential malware on your Red Hat Enterprise Linux systems."
           },
-          "rhel.remediations"
+          "rhel.remediations",
+          "settings.idmsvc"
         ]
       },
       {


### PR DESCRIPTION
Add the *Directory and Domain Services* (`idmsvc`) service to the services directory.  Improve the description and include a bunch of relevant search terms to help users find the service.

Stage only.  The service is not yet in prod.