### PR TITLE
chore: put Drift navigations behind a feature flag

### DIFF
--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -242,6 +242,12 @@
                             "href": "/ansible/drift/baselines",
                             "product": "Red Hat Insights"
                         }
+                    ],
+                    "permissions": [
+                        {
+                          "method": "featureFlag",
+                          "args": ["insights.drift.isSunset", false]
+                        }
                     ]
                 },
                 {

--- a/static/stable/prod/navigation/rhel-navigation.json
+++ b/static/stable/prod/navigation/rhel-navigation.json
@@ -371,6 +371,12 @@
               "href": "/insights/drift/baselines",
               "product": "Red Hat Insights"
             }
+          ],
+          "permissions": [
+            {
+              "method": "featureFlag",
+              "args": ["insights.drift.isSunset", false]
+            }
           ]
         },
         {

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -266,7 +266,13 @@
             "title": "Drift",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "Compare systems in your Red Hat Enterprise Linux inventory to one another or against a set baseline."
+            "description": "Compare systems in your Red Hat Enterprise Linux inventory to one another or against a set baseline.",
+            "permissions": [
+              {
+                "method": "featureFlag",
+                "args": ["insights.drift.isSunset", false]
+              }
+            ]
           },
           "rhel.policies"
         ]
@@ -349,7 +355,13 @@
             "href": "/ansible/drift",
             "icon": "AnsibleIcon",
             "subtitle": "Red Hat Insights for Ansible",
-            "description": "Compare systems in your Ansible inventory to one another or against a set baseline."
+            "description": "Compare systems in your Ansible inventory to one another or against a set baseline.",
+            "permissions": [
+              {
+                "method": "featureFlag",
+                "args": ["insights.drift.isSunset", false]
+              }
+            ]
           },
           "ansible.policies"
         ]

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -235,6 +235,12 @@
                             "href": "/ansible/drift/baselines",
                             "product": "Red Hat Insights"
                         }
+                    ],
+                    "permissions": [
+                        {
+                          "method": "featureFlag",
+                          "args": ["insights.drift.isSunset", false]
+                        }
                     ]
                 },
                 {

--- a/static/stable/stage/navigation/rhel-navigation.json
+++ b/static/stable/stage/navigation/rhel-navigation.json
@@ -359,6 +359,12 @@
               "href": "/insights/drift/baselines",
               "product": "Red Hat Insights"
             }
+          ],
+          "permissions": [
+            {
+              "method": "featureFlag",
+              "args": ["insights.drift.isSunset", false]
+            }
           ]
         },
         {

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -261,7 +261,13 @@
             "title": "Drift",
             "icon": "InsightsIcon",
             "subtitle": "Red Hat Insights for RHEL",
-            "description": "Compare systems in your Red Hat Enterprise Linux inventory to one another or against a set baseline."
+            "description": "Compare systems in your Red Hat Enterprise Linux inventory to one another or against a set baseline.",
+            "permissions": [
+              {
+                "method": "featureFlag",
+                "args": ["insights.drift.isSunset", false]
+              }
+            ]
           },
           "rhel.policies"
         ]
@@ -344,7 +350,13 @@
             "href": "/ansible/drift",
             "icon": "AnsibleIcon",
             "subtitle": "Red Hat Insights for Ansible",
-            "description": "Compare systems in your Ansible inventory to one another or against a set baseline."
+            "description": "Compare systems in your Ansible inventory to one another or against a set baseline.",
+            "permissions": [
+              {
+                "method": "featureFlag",
+                "args": ["insights.drift.isSunset", false]
+              }
+            ]
           },
           "ansible.policies"
         ]


### PR DESCRIPTION
The Drift application is being sunset as of 1th of October. This PR puts both stage and prod navigations and services.json behind the flag `insights.drift.isSunset`. After 1th of October, we will remove all the Drift related configs with this [PR](https://github.com/RedHatInsights/chrome-service-backend/pull/679). 