### PR TITLE
feat(HMS-4758): display idmsvc in prod

### DIFF
--- a/static/stable/prod/main.yml
+++ b/static/stable/prod/main.yml
@@ -103,6 +103,12 @@ content-sources:
     versions:
       - v1
 
+idmsvc:
+  title: Directory and Domain services
+  api:
+    versions:
+      - v1
+
 cost-management:
   title: Cost Management
   api:

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -916,6 +916,21 @@
             }
         ]
     },
+    "idmsvc": {
+        "manifestLocation": "/apps/idmsvc/fed-mods.json",
+        "defaultDocumentTitle": "Directory and Domain Services",
+        "modules": [
+            {
+                "id": "idmsvc",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/settings/idmsvc"
+                    }
+                ]
+            }
+        ]
+    },
     "learningResources": {
         "manifestLocation": "/apps/learning-resources/fed-mods.json",
         "modules": [

--- a/static/stable/prod/navigation/settings-navigation.json
+++ b/static/stable/prod/navigation/settings-navigation.json
@@ -88,6 +88,35 @@
           "appId": "learningResources",
           "title": "Learning Resources",
           "href": "/settings/learning-resources"
-      }
+      },
+      {
+          "id": "idmsvc",
+          "appId": "idmsvc",
+          "title": "Directory and Domain Services",
+          "description": "Register identity and access systems to enable machines to automatically join a domain",
+          "href": "/settings/idmsvc",
+          "icon": "PlaceholderIcon",
+          "permissions": [
+            {
+              "method": "isBeta"
+            }
+          ],
+          "alt_title": [
+              "directory",
+              "domain",
+              "ipa",
+              "freeipa",
+              "idm",
+              "sssd",
+              "ldap",
+              "kerberos",
+              "join",
+              "enrol",
+              "enroll",
+              "authentication",
+              "authorisation",
+              "authorization"
+            ]
+        }
   ]
 }

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -161,6 +161,13 @@
             "description": "Authenticate and connect securely to APIs from multiple services."
           }
         ]
+      },
+      {
+        "isGroup": true,
+        "title": "Host Identity",
+        "links": [
+          "settings.idmsvc"
+        ]
       }
     ]
   },
@@ -175,6 +182,7 @@
         "title": "Console Settings",
         "links": [
           "settings.integrations",
+          "settings.idmsvc",
           "settings.notifications"
         ]
       }
@@ -422,7 +430,8 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify potential malware on your Red Hat Enterprise Linux systems."
           },
-          "rhel.remediations"
+          "rhel.remediations",
+          "settings.idmsvc"
         ]
       },
       {


### PR DESCRIPTION
This change copy the configuration from stage to prod to make the Directory and Domain services available in production.

NOTE: This depends on promoting frontend and backend to production.

TODO:

- [x] Update metadata to display idmsvc in the left panel.

https://issues.redhat.com/browse/HMS-4758