### PR TITLE
Widgets for itless environment

### DIFF
--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -353,6 +353,7 @@ type ModuleFederationMetadata struct {
 	Scope      string               `json:"scope"`
 	Module     string               `json:"module"`
 	ImportName string               `json:"importName,omitempty"`
+	FeatureFlag string              `json:"featureFlag,omitempty"`
 	Defaults   BaseWidgetDimensions `json:"defaults"`
 	Config     WidgetConfiguration  `json:"config"`
 }

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/RedHatInsights/chrome-service-backend/rest/models"
 	"github.com/RedHatInsights/chrome-service-backend/rest/service"
 	"github.com/RedHatInsights/chrome-service-backend/rest/util"
+	"github.com/RedHatInsights/chrome-service-backend/rest/featureflags"
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -280,6 +281,15 @@ func GetWidgetMappings(w http.ResponseWriter, r *http.Request) {
 	handleDashboardResponse[models.WidgetModuleFederationMapping](resp, err, w)
 }
 
+func GetWidgetMappingsFR(w http.ResponseWriter, r *http.Request) {
+	var err error
+	resp := util.EntityResponse[models.WidgetModuleFederationMapping]{
+		Data: service.WidgetMappingFR,
+	}
+
+	handleDashboardResponse[models.WidgetModuleFederationMapping](resp, err, w)
+}
+
 func ResetDashboardTemplate(w http.ResponseWriter, r *http.Request) {
 	user := r.Context().Value(util.USER_CTX_KEY).(models.UserIdentity)
 	userID := user.ID
@@ -323,5 +333,9 @@ func MakeDashboardTemplateRoutes(sub chi.Router) {
 	sub.Get("/base-template", GetBaseDashboardTemplates)
 	sub.Get("/base-template/fork", ForkBaseTemplate)
 
-	sub.Get("/widget-mapping", GetWidgetMappings)
+	if featureflags.IsEnabled("chrome-service.itless.enabled") {
+		sub.Get("/widget-mapping", GetWidgetMappingsFR)
+	} else {
+		sub.Get("/widget-mapping", GetWidgetMappings)
+	}
 }

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -272,16 +272,16 @@ func DecodeDashboardTemplate(w http.ResponseWriter, r *http.Request) {
 	handleDashboardResponse[models.DashboardTemplate](resp, err, w)
 }
 
-func FilterWidgetMapping(widgetMapping models.WidgetModuleFederationMapping) models.WidgetModuleFederationMapping {
-	filteredWidgets := make(map[models.AvailableWidgets]models.ModuleFederationMetadata)
 
+// FilterWidgetMapping removes hidden widgets from the mapping by using feature flags stored with the widget definition.
+func FilterWidgetMapping(widgetMapping models.WidgetModuleFederationMapping) models.WidgetModuleFederationMapping {
 	for key, value := range widgetMapping {
-		if !featureflags.IsEnabled(value.FeatureFlag) {
-			filteredWidgets[key] = value	
+		if featureflags.IsEnabled(value.FeatureFlag) {
+			delete(widgetMapping, key)	
 		}
 	}
 
-	return filteredWidgets
+	return widgetMapping
 }
 
 func GetWidgetMappings(w http.ResponseWriter, r *http.Request) {

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -333,7 +333,7 @@ func MakeDashboardTemplateRoutes(sub chi.Router) {
 	sub.Get("/base-template", GetBaseDashboardTemplates)
 	sub.Get("/base-template/fork", ForkBaseTemplate)
 
-	if featureflags.IsEnabled("chrome-service.itless.enabled") {
+	if featureflags.IsEnabled("platform.chrome.itless") {
 		sub.Get("/widget-mapping", GetWidgetMappingsFR)
 	} else {
 		sub.Get("/widget-mapping", GetWidgetMappings)

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -209,6 +209,66 @@ var (
 		},
 	},
 	}
+	WidgetMappingFR models.WidgetModuleFederationMapping = models.WidgetModuleFederationMapping{
+		models.Rhel: models.ModuleFederationMetadata{
+			Scope:    "landing",
+			Module:   "./RhelWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			Config: models.WidgetConfiguration{
+				Icon:  models.RhelIcon,
+				Title: "Red Hat Enterprise Linux",
+			},
+		},
+		models.OpenShift: models.ModuleFederationMetadata{
+			Scope:    "landing",
+			Module:   "./OpenShiftWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			Config: models.WidgetConfiguration{
+				Icon:  models.OpenShiftIcon,
+				Title: "Red Hat OpenShift",
+			},
+		},
+		models.RecentlyVisited: models.ModuleFederationMetadata{
+			Scope:    "landing",
+			Module:   "./RecentlyVisited",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
+			Config: models.WidgetConfiguration{
+				Icon:  models.HistoryIcon,
+				Title: "Recently visited",
+			},
+		},
+		models.FavoriteServices: models.ModuleFederationMetadata{
+			Scope:    "chrome",
+			Module:   "./DashboardFavorites",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
+			Config: models.WidgetConfiguration{
+				HeaderLink: models.WidgetHeaderLink{
+					Title: "View all services",
+					Href:  "/allservices",
+				},
+				Icon:  models.StarIcon,
+				Title: "My favorite services",
+			},
+		},
+		models.NotificationsEvents: models.ModuleFederationMetadata{
+			Scope:    "notifications",
+			Module:   "./DashboardWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
+			Config: models.WidgetConfiguration{
+				HeaderLink: models.WidgetHeaderLink{
+					Title: "View event log",
+					Href:  "/settings/notifications/eventlog",
+				},
+				Icon:  models.BellIcon,
+				Title: "Events",
+				Permissions: []models.WidgetPermission{
+					models.WidgetPermission{
+						Method: models.OrgAdmin,
+					},
+				},
+			},
+		},
+	}
 )
 
 func ForkBaseTemplate(userId uint, dashboard models.AvailableTemplates) (models.DashboardTemplate, error) {

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -27,7 +27,7 @@ var (
 			Scope:    "landing",
 			Module:   "./ExploreCapabilities",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 3, 5, 10, 1),
-
+			FeatureFlag: "widget.exploreCapabilities.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.RocketIcon,
 				Title: "Explore capabilities",
@@ -37,6 +37,7 @@ var (
 			Scope:    "landing",
 			Module:   "./EdgeWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			FeatureFlag: "widget.edge.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.EdgeIcon,
 				Title: "Edge Management",
@@ -46,6 +47,7 @@ var (
 			Scope:    "landing",
 			Module:   "./AnsibleWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			FeatureFlag: "widget.ansible.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.AnsibleIcon,
 				Title: "Ansible Automation Platform",
@@ -55,6 +57,7 @@ var (
 			Scope:    "landing",
 			Module:   "./RhelWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			FeatureFlag: "widget.rhel.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.RhelIcon,
 				Title: "Red Hat Enterprise Linux",
@@ -64,6 +67,7 @@ var (
 			Scope:    "landing",
 			Module:   "./OpenShiftWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			FeatureFlag: "widget.openshift.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.OpenShiftIcon,
 				Title: "Red Hat OpenShift",
@@ -73,6 +77,7 @@ var (
 			Scope:    "landing",
 			Module:   "./QuayWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			FeatureFlag: "widget.quay.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.QuayIcon,
 				Title: "Quay.io",
@@ -82,6 +87,7 @@ var (
 			Scope:    "landing",
 			Module:   "./AcsWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			FeatureFlag: "widget.acs.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.ACSIcon,
 				Title: "Advanced Cluster Security",
@@ -91,6 +97,7 @@ var (
 			Scope:    "landing",
 			Module:   "./OpenShiftAiWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			FeatureFlag: "widget.openshiftAI.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.OpenShiftAiIcon,
 				Title: "Red Hat OpenShift AI",
@@ -100,6 +107,7 @@ var (
 			Scope:    "landing",
 			Module:   "./RecentlyVisited",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
+			FeatureFlag: "widget.recentlyVisited.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.HistoryIcon,
 				Title: "Recently visited",
@@ -109,6 +117,7 @@ var (
 			Scope:    "chrome",
 			Module:   "./DashboardFavorites",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
+			FeatureFlag: "widget.favoriteServices.hidden",
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "View all services",
@@ -122,6 +131,7 @@ var (
 			Scope:    "notifications",
 			Module:   "./DashboardWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
+			FeatureFlag: "widget.notificationsEvents.hidden",
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "View event log",
@@ -140,6 +150,7 @@ var (
 			Scope:    "learningResources",
 			Module:   "./BookmarkedLearningResourcesWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
+			FeatureFlag: "widget.learningResources.hidden",
 			Config: models.WidgetConfiguration{
 				Icon:  models.OutlinedBookmarkIcon,
 				Title: "Bookmarked learning resources",
@@ -149,6 +160,7 @@ var (
 			Scope:    "landing",
 			Module:   "./SupportCaseWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
+			FeatureFlag: "widget.supportCases.hidden",
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "Open a support case",
@@ -162,6 +174,7 @@ var (
 			Scope:    "subscriptionInventory",
 			Module:   "./SubscriptionsWidget",
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 4, 4, 10, 1),
+			FeatureFlag: "widget.subscriptions.hidden",
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "Manage subscriptions",
@@ -190,6 +203,7 @@ var (
 		Scope:    "sources",
 		Module:   "./IntegrationsWidget",
 		Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
+		FeatureFlag: "widget.integrations.hidden",
 		Config: models.WidgetConfiguration{
 			HeaderLink: models.WidgetHeaderLink{
 				Title: "Explore integrations",
@@ -208,66 +222,6 @@ var (
 			},
 		},
 	},
-	}
-	WidgetMappingFR models.WidgetModuleFederationMapping = models.WidgetModuleFederationMapping{
-		models.Rhel: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./RhelWidget",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			Config: models.WidgetConfiguration{
-				Icon:  models.RhelIcon,
-				Title: "Red Hat Enterprise Linux",
-			},
-		},
-		models.OpenShift: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./OpenShiftWidget",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			Config: models.WidgetConfiguration{
-				Icon:  models.OpenShiftIcon,
-				Title: "Red Hat OpenShift",
-			},
-		},
-		models.RecentlyVisited: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./RecentlyVisited",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
-			Config: models.WidgetConfiguration{
-				Icon:  models.HistoryIcon,
-				Title: "Recently visited",
-			},
-		},
-		models.FavoriteServices: models.ModuleFederationMetadata{
-			Scope:    "chrome",
-			Module:   "./DashboardFavorites",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
-			Config: models.WidgetConfiguration{
-				HeaderLink: models.WidgetHeaderLink{
-					Title: "View all services",
-					Href:  "/allservices",
-				},
-				Icon:  models.StarIcon,
-				Title: "My favorite services",
-			},
-		},
-		models.NotificationsEvents: models.ModuleFederationMetadata{
-			Scope:    "notifications",
-			Module:   "./DashboardWidget",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
-			Config: models.WidgetConfiguration{
-				HeaderLink: models.WidgetHeaderLink{
-					Title: "View event log",
-					Href:  "/settings/notifications/eventlog",
-				},
-				Icon:  models.BellIcon,
-				Title: "Events",
-				Permissions: []models.WidgetPermission{
-					models.WidgetPermission{
-						Method: models.OrgAdmin,
-					},
-				},
-			},
-		},
 	}
 )
 


### PR DESCRIPTION
Within the itless environment, not all services are available so not all widgets should be available by default for the customers in that environment. This is meant to resolve that using a feature flag that will be checked to ensure that if a customer is in an itless env, they'll get only a subset of the available widgets.

Working on this a bit with @florkbr. 