### PR TITLE
AAP-27533 Add Top Level Cluster List Navigation to CRC 

### DIFF
--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -16,6 +16,12 @@
             "href": "/ansible/learning-resources"
         },
         {
+            "title": "Cluster List",
+            "id": "clusterList",
+            "appId": "automationAnalytics",
+            "href": "/ansible/automation-analytics/cluster-list"
+        },
+        {
             "title": "Automation Hub",
             "expandable": true,
             "routes": [


### PR DESCRIPTION
This PR is to help set up a dev workflow for all work in AAP-27533. Using this PR, one can create a local chrome service backend with updated nav components for cluster list. In other apps such as analytics, requests can be proxied to this backend to get the updated top level nav when doing development within a specific app.