### PR TITLE
Disable the Red Hat user only filter we had in place before GA

### DIFF
--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -1044,13 +1044,6 @@
                 "module": "./RootApp",
                 "routes": [
                     {
-                        "permissions": [
-                            {
-                                "method": "withEmail",
-                                "args": ["@redhat.com"]
-                                
-                            }
-                        ],
                         "pathname": "/ansible/service/"
                     }
                 ]

--- a/static/stable/prod/navigation/ansible-navigation.json
+++ b/static/stable/prod/navigation/ansible-navigation.json
@@ -144,13 +144,6 @@
                     "description": "Ansible as a managed service instances",
                     "title": "Instances",
                     "icon": "AnsibleIcon",
-                    "permissions": [
-                        {
-                            "method": "withEmail",
-                            "args": ["@redhat.com"]
-                            
-                        }
-                    ],
                     "product": "Ansible as a Service",
                     "href": "/ansible/service/instances"
                 }


### PR DESCRIPTION
Our offering is about to be GA so we need to remove the check that only let Red Hat users access it.

For issue https://issues.redhat.com/browse/AAP-33834