### PR TITLE
fix: require perms to use intergrations widget

### DIFF
--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -331,9 +331,10 @@ type WidgetHeaderLink struct {
 type WidgetPermissionMethods string
 
 const (
-	OrgAdmin       WidgetPermissionMethods = "isOrgAdmin"
-	FeatureFlag    WidgetPermissionMethods = "featureFlag"
-	HasPermissions WidgetPermissionMethods = "hasPermissions"
+	OrgAdmin         WidgetPermissionMethods = "isOrgAdmin"
+	FeatureFlag      WidgetPermissionMethods = "featureFlag"
+	HasPermissions   WidgetPermissionMethods = "hasPermissions"
+	LoosePermissions WidgetPermissionMethods = "loosePermissions"
 )
 
 type WidgetPermission struct {

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -219,6 +219,12 @@ var (
 						true,
 					},
 				},
+				models.WidgetPermission{
+					Method: models.LoosePermissions,
+					Args: []any{
+						[]string{"sources:*:read", "integrations:endpoints:read"},
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION
[RHCLOUD-36314](https://issues.redhat.com/browse/RHCLOUD-36314)
- Require either `sources:*:read` or `integrations:endpoints:read` in order to use the Integrations Widget.
- Permissions requirements to create integrations within the widget is handled by https://github.com/RedHatInsights/sources-ui/pull/1273