### PR TITLE
[CIAM-9118] idp integration route id fix

### DIFF
--- a/static/beta/stage/navigation/iam-navigation.json
+++ b/static/beta/stage/navigation/iam-navigation.json
@@ -177,7 +177,7 @@
           "description": "Manage how your organization authenticates to Red Hat services."
         },
         {
-          "id": "idpintegration",
+          "id": "idpIntegration",
           "appId": "iam",
           "title": "Identity Provider Integration",
           "href": "/iam/authentication-policy/identity-provider-integration",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -147,7 +147,8 @@
         "links": [
           "iam.users",
           "iam.groups",
-          "iam.authFactors"
+          "iam.authFactors",
+          "iam.idpIntegration"
         ]
       },
       {

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -148,7 +148,8 @@
           "iam.users",
           "iam.groups",
           "iam.authFactors",
-          "iam.serviceAccounts"
+          "iam.serviceAccounts",
+          "iam.idpIntegration"
         ]
       },
       {


### PR DESCRIPTION
Hello team,
Tickets tries to solve https://issues.redhat.com/browse/CIAM-8796

Our primary goal is to understand and enable the 'Identity Provider Integration' menu-item, which is also part of the 'Authentication Policy' menu that already includes the existing searchable item '**authFactors**.' We’ve noticed that this item isn’t yet available in the **staging** or **prod** environments, and I’m not entirely sure if this unique change will fix and enable it since all searchable content is created through `parse-services` and `generate-search-index` GO tasks.

![image](https://github.com/user-attachments/assets/8d5d9be6-10cb-4701-8812-9320e4207137)

That said, I did a search for both ids and got:

**iam.authFactors** references:
```
api/chrome-service/v1/static/stable/prod/search/search-index.json
api/chrome-service/v1/static/stable/prod/services/links-storage.json
api/chrome-service/v1/static/stable/prod/services/services.json

api/chrome-service/v1/static/stable/stage/search/search-index.json
api/chrome-service/v1/static/stable/stage/services/links-storage.json
api/chrome-service/v1/static/stable/stage/services/services.json

api/chrome-service/v1/static/beta/prod/search/search-index.json
api/chrome-service/v1/static/beta/prod/services/links-storage.json
api/chrome-service/v1/static/beta/prod/services/services.json
api/chrome-service/v1/static/beta/prod/services/services.json
api/chrome-service/v1/static/beta/stage/services/links-storage.json
api/chrome-service/v1/static/beta/stage/services/services.json

static/stable/prod/services/services.json
static/stable/prod/search/search-index.json
static/stable/prod/services/links-storage.json
static/stable/stage/search/search-index.json
static/stable/stage/services/links-storage.json
static/stable/stage/services/services.json

static/beta/prod/search/search-index.json
static/beta/prod/services/links-storage.json
static/beta/prod/services/services.json
static/beta/stage/search/search-index.json
static/beta/stage/services/links-storage.json
static/beta/stage/services/services.json
```

**iam.idpIntegration** references:
```
api/chrome-service/v1/static/stable/prod/search/search-index.json
api/chrome-service/v1/static/stable/prod/services/links-storage.json
api/chrome-service/v1/static/stable/prod/services/services.json

-- (missing) --> api/chrome-service/v1/static/stable/stage/search/search-index.json
api/chrome-service/v1/static/stable/stage/services/links-storage.json
-- (missing) --> api/chrome-service/v1/static/stable/stage/services/services.json

api/chrome-service/v1/static/beta/prod/services/links-storage.json
api/chrome-service/v1/static/beta/stage/services/links-storage.json

static/stable/prod/search/search-index.json
static/stable/prod/services/links-storage.json
static/stable/prod/services/services.json

-- (missing) --> static/stable/stage/search/search-index.json
static/stable/stage/services/links-storage.json
-- (missing) --> static/stable/stage/services/services.json

static/beta/prod/services/links-storage.json
static/beta/stage/services/links-storage.json
```

Why
The CIAM-S AuthN is currently working to provide a self-service 3rd party Identity Provider solution for Red Hat external customers.

our team channel:
[team-ciam-s-authn](https://redhat.enterprise.slack.com/archives/C04PS3GSJKC)

Appreciate all support in advance