### PR TITLE
task: remove patchTemplates from itless envs

### DIFF
--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -144,13 +144,6 @@
                 "systems",
                 "upgrade"
               ]
-            },
-            {
-              "id": "patchTemplates",
-              "appId": "patch",
-              "title": "Templates",
-              "href": "/insights/patch/templates",
-              "product": "Red Hat Insights"
             }
           ]
         }

--- a/static/stable/itless/navigation/insights-navigation.json
+++ b/static/stable/itless/navigation/insights-navigation.json
@@ -144,13 +144,6 @@
                 "systems",
                 "upgrade"
               ]
-            },
-            {
-              "id": "patchTemplates",
-              "appId": "patch",
-              "title": "Templates",
-              "href": "/insights/patch/templates",
-              "product": "Red Hat Insights"
             }
           ]
         }


### PR DESCRIPTION
These templates are unneeded in the ITless environment so we do not want the link to appear in the navigation.