### PR TITLE
Add Manage Satellite to side nav in itless

### DIFF
--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -66,7 +66,6 @@
                 }
               ]
         },
-        ,
         {
           "id": "satellite",
           "appId": "satellite-token",

--- a/static/beta/itless/navigation/rhel-navigation.json
+++ b/static/beta/itless/navigation/rhel-navigation.json
@@ -65,6 +65,21 @@
                   "args": ["platform.rbac.groups-to-workspaces-rename", true]
                 }
               ]
+        },
+        ,
+        {
+          "id": "satellite",
+          "appId": "satellite-token",
+          "title": "Configure Satellites",
+          "href": "/insights/satellite",
+          "product": "Red Hat Insights",
+          "description": "Configure satellite servers and tokens.",
+          "alt_title": [
+            "configure satellite",
+            "satellites",
+            "satellite",
+            "manage satellite"
+          ]
         }
       ]
     },

--- a/static/stable/itless/navigation/insights-navigation.json
+++ b/static/stable/itless/navigation/insights-navigation.json
@@ -65,6 +65,20 @@
                   "args": ["platform.rbac.groups-to-workspaces-rename", true]
                 }
               ]
+        },
+        {
+          "id": "satellite",
+          "appId": "satellite-token",
+          "title": "Configure Satellites",
+          "href": "/insights/satellite",
+          "product": "Red Hat Insights",
+          "description": "Configure satellite servers and tokens.",
+          "alt_title": [
+            "configure satellite",
+            "satellites",
+            "satellite",
+            "manage satellite"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Removing Satellite from header for itless: [Here](https://github.com/RedHatInsights/insights-chrome/pull/3000)
Moving this to the side nav in itless env.

Vuln check fixed here: https://github.com/RedHatInsights/chrome-service-backend/pull/770