### PR TITLE
fix: add service accounts icon/description

### DIFF
--- a/static/stable/prod/navigation/iam-navigation.json
+++ b/static/stable/prod/navigation/iam-navigation.json
@@ -192,6 +192,8 @@
       "title": "Service Accounts",
       "appId": "serviceAccounts",
       "href": "/iam/service-accounts",
+      "icon": "ServicesIcon",            
+      "description": "Authenticate and connect securely to APIs from multiple services.",
       "permissions": [
         {
           "method": "featureFlag",

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -191,7 +191,9 @@
       "title": "Service Accounts",
       "appId": "serviceAccounts",
       "feoReplacement": "service-accounts",
-      "href": "/iam/service-accounts"
+      "href": "/iam/service-accounts",
+      "icon": "ServicesIcon",            
+      "description": "Authenticate and connect securely to APIs from multiple services."
     },
     {
       "id": "learningResources",


### PR DESCRIPTION
[RHCLOUD-37639](https://issues.redhat.com/browse/RHCLOUD-37639)

Service Accounts icon and description was missing. 