### PR TITLE
fix: show event log for notif admin

### DIFF
--- a/static/beta/itless/navigation/settings-navigation.json
+++ b/static/beta/itless/navigation/settings-navigation.json
@@ -33,7 +33,13 @@
                   "href": "/settings/notifications/eventlog",
                   "permissions": [
                     {
-                      "method": "isOrgAdmin"
+                      "method": "loosePermissions",
+                      "args": [
+                        [
+                          "notifications:*:*",
+                          "notifications:notifications:write"
+                        ]
+                      ]
                     }
                   ]
               },

--- a/static/beta/prod/navigation/settings-navigation.json
+++ b/static/beta/prod/navigation/settings-navigation.json
@@ -71,7 +71,13 @@
                   "href": "/settings/notifications/eventlog",
                   "permissions": [
                     {
-                      "method": "isOrgAdmin"
+                      "method": "loosePermissions",
+                      "args": [
+                        [
+                          "notifications:*:*",
+                          "notifications:notifications:write"
+                        ]
+                      ]
                     }
                   ]
               },

--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -86,7 +86,13 @@
                     "href": "/settings/notifications/eventlog",
                     "permissions": [
                       {
-                        "method": "isOrgAdmin"
+                        "method": "loosePermissions",
+                        "args": [
+                          [
+                            "notifications:*:*",
+                            "notifications:notifications:write"
+                          ]
+                        ]
                       }
                     ]
                 },

--- a/static/stable/itless/navigation/settings-navigation.json
+++ b/static/stable/itless/navigation/settings-navigation.json
@@ -33,7 +33,13 @@
                   "href": "/settings/notifications/eventlog",
                   "permissions": [
                     {
-                      "method": "isOrgAdmin"
+                      "method": "loosePermissions",
+                      "args": [
+                        [
+                          "notifications:*:*",
+                          "notifications:notifications:write"
+                        ]
+                      ]
                     }
                   ]
               },

--- a/static/stable/prod/navigation/settings-navigation.json
+++ b/static/stable/prod/navigation/settings-navigation.json
@@ -71,7 +71,13 @@
                 "href": "/settings/notifications/eventlog",
                 "permissions": [
                   {
-                    "method": "isOrgAdmin"
+                    "method": "loosePermissions",
+                    "args": [
+                      [
+                        "notifications:*:*",
+                        "notifications:notifications:write"
+                      ]
+                    ]
                   }
                 ]
             },

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -72,7 +72,13 @@
                   "href": "/settings/notifications/eventlog",
                   "permissions": [
                     {
-                      "method": "isOrgAdmin"
+                      "method": "loosePermissions",
+                      "args": [
+                        [
+                          "notifications:*:*",
+                          "notifications:notifications:write"
+                        ]
+                      ]
                     }
                   ]
               },


### PR DESCRIPTION
[RHCLOUD-37059](https://issues.redhat.com/browse/RHCLOUD-37059)
- Show **Event Log** page to users with `notifications:notifications:write` permission. 
**(provided by `notification-admin` role)**