### PR TITLE
feat: Add Itless default layout for widgets

### DIFF
--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -16,7 +16,8 @@ import (
 type AvailableTemplates string
 
 const (
-	LandingPage AvailableTemplates = "landingPage"
+	LandingPage AvailableTemplates       = "landingPage"
+	LandingPageItless AvailableTemplates = "landingPageItless"
 )
 
 func (at *AvailableTemplates) Scan(value interface{}) error {
@@ -35,6 +36,8 @@ func (at AvailableTemplates) String() string {
 func (at AvailableTemplates) IsValid() error {
 	switch at {
 	case LandingPage:
+		return nil
+	case LandingPageItless:
 		return nil
 	}
 

--- a/rest/service/dashboardTemplate_test.go
+++ b/rest/service/dashboardTemplate_test.go
@@ -339,10 +339,13 @@ func TestGetAllUserDashboardTemplates(t *testing.T) {
 
 	t.Run("GetAllBaseTemplates should return all base templates", func(t *testing.T) {
 		baseTemplates := GetAllBaseTemplates()
-		assert.Equal(t, 1, len(baseTemplates))
+		assert.Equal(t, 2, len(baseTemplates))
 		assert.Equal(t, BaseTemplates[models.LandingPage].Name, baseTemplates[0].Name)
 		assert.Equal(t, BaseTemplates[models.LandingPage].DisplayName, baseTemplates[0].DisplayName)
 		assert.Equal(t, BaseTemplates[models.LandingPage].TemplateConfig, baseTemplates[0].TemplateConfig)
+		assert.Equal(t, BaseTemplates[models.LandingPageItless].Name, baseTemplates[1].Name)
+		assert.Equal(t, BaseTemplates[models.LandingPageItless].DisplayName, baseTemplates[1].DisplayName)
+		assert.Equal(t, BaseTemplates[models.LandingPageItless].TemplateConfig, baseTemplates[1].TemplateConfig)
 	})
 
 	t.Run("GetDashboardTemplateBase should return error if template type does not exist", func(t *testing.T) {

--- a/static/stable/itless/modules/fed-modules.json
+++ b/static/stable/itless/modules/fed-modules.json
@@ -9,7 +9,10 @@
                 "routes": [
                     {
                         "exact": true,
-                        "pathname": "/"
+                        "pathname": "/",
+                        "props": {
+                          "layoutType": "landingPageItless"
+                        }
                     }
                 ]
             }

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -10,7 +10,10 @@
                 "routes": [
                     {
                         "exact": true,
-                        "pathname": "/"
+                        "pathname": "/",
+                        "props": {
+                            "layoutType": "landingPage"
+                        }
                     }
                 ]
             }

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -11,7 +11,10 @@
               "routes": [
                   {
                       "exact": true,
-                      "pathname": "/"
+                      "pathname": "/",
+                      "props": {
+                         "layoutType": "landingPage"
+                        }
                   }
               ]
           }

--- a/widget-dashboard-defaults/landingItless.yaml
+++ b/widget-dashboard-defaults/landingItless.yaml
@@ -1,0 +1,122 @@
+# yaml-language-server: $schema=./widget-schema.json
+
+name: landingPageItless
+displayName: LandingPageItless
+templateConfig:
+  sm:
+    - x: 0
+      y: 0
+      i: 'rhel#rhel'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 0
+      y: 0
+      i: 'openshift#openshift'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 0
+      y: 0
+      i: 'recentlyVisited#recentlyVisited'
+      w: 1
+      h: 7
+      maxH: 10
+      minH: 1
+    - x: 0
+      y: 0 
+      i: 'favoriteServices#favoriteServices'
+      w: 1
+      h: 6
+      maxH: 10
+      minH: 1
+  md:
+    - x: 0
+      y: 0
+      i: 'rhel#rhel'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 0
+      y: 1
+      i: 'openshift#openshift'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 1
+      y: 0
+      i: 'recentlyVisited#recentlyVisited'
+      w: 1
+      h: 6
+      maxH: 10
+      minH: 1
+    - x: 1
+      y: 1
+      i: 'favoriteServices#favoriteServices'
+      w: 1
+      h: 6
+      maxH: 10
+      minH: 1
+  lg:
+    - x: 0
+      y: 0
+      i: 'rhel#rhel'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 1
+      y: 0
+      i: 'openshift#openshift'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 2
+      y: 0
+      i: 'recentlyVisited#recentlyVisited'
+      w: 1
+      h: 7
+      maxH: 10
+      minH: 1     
+    - x: 3 
+      y: 0
+      i: 'favoriteServices#favoriteServices'
+      w: 1
+      h: 7
+      maxH: 10
+      minH: 1
+  xl:
+    - x: 0
+      y: 0
+      i: 'rhel#rhel'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 1
+      y: 0
+      i: 'openshift#openshift'
+      w: 1
+      h: 4
+      maxH: 10
+      minH: 1
+    - x: 2 
+      y: 0
+      i: 'recentlyVisited#recentlyVisited'
+      w: 1
+      h: 7
+      maxH: 10
+      minH: 1
+    - x: 3 
+      y: 0
+      i: 'favoriteServices#favoriteServices'
+      w: 1
+      h: 7
+      maxH: 10
+      minH: 1
+


### PR DESCRIPTION
Add an Itless default widget layout. There are several widgets that are unavailable in the itless environments. This is meant to create a nicer default widget layout when those widgets are hidden or unavailable.