### PR TITLE
Added OpenShift Virtualization link to side navigation

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -256,6 +256,12 @@
               "filterable": false
             }
           ]
+        },
+        {
+          "id": "openshiftVirtualization",
+          "title": "OpenShift Virtualization",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
         }
       ]
     },

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -255,6 +255,12 @@
               "filterable": false
             }
           ]
+        },
+        {
+          "id": "openshiftVirtualization",
+          "title": "OpenShift Virtualization",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
         }
       ]
     },

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -256,6 +256,12 @@
               "filterable": false
             }
           ]
+        },
+        {
+          "id": "openshiftVirtualization",
+          "title": "OpenShift Virtualization",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
         }
       ]
     },

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -255,6 +255,12 @@
               "filterable": false
             }
           ]
+        },
+        {
+          "id": "openshiftVirtualization",
+          "title": "OpenShift Virtualization",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
         }
       ]
     },


### PR DESCRIPTION
Update to configs to enable additional external link in the left hand navigation menu of consoledot leading to the OpenShift Virtualization product page.

Jira Ticket: [OCMUI-3001](https://issues.redhat.com/browse/OCMUI-3001)