### PR TITLE
Place search result for global learning resources behind feature flag

### DIFF
--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -43,7 +43,13 @@
         "id": "globalLearningResourcesPage",
         "href": "/learning-resources",
         "title": "All Learning Resources",
-        "description": "Access product documentation, tutorials, and other learning materials to support your Red Hat product use."
+        "description": "Access product documentation, tutorials, and other learning materials to support your Red Hat product use.",
+        "permissions": [
+          {
+            "method": "featureFlag",
+            "args": ["platform.learning-resources.global-learning-resources", true]
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
Follow up to https://github.com/RedHatInsights/chrome-service-backend/pull/789

We need to place the search result for global learning resources behind the dark launch flag as well.