### PR TITLE
updating builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739801907 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22-1742197705 AS builder
 WORKDIR $GOPATH/src/chrome-service-backend/
 # TODO: Use --exclude when stable docker version available
 COPY api api


### PR DESCRIPTION
Updating the `go-toolset` builder image to the latest version.