### PR TITLE
[RSPEED-813] Add roadmap to stage preview

### DIFF
--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1178,5 +1178,22 @@
     "runtimes": {
         "manifestLocation": "/apps/runtimes/fed-mods.json",
         "modules": []
+    },
+    "roadmap": {
+        "manifestLocation": "/apps/roadmap/fed-mods.json",
+        "modules": [
+            {
+                "id": "roadmap",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/digital-roadmap/lifecycle"
+                    },
+                    {
+                        "pathname": "/digital-roadmap/roadmap"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1187,10 +1187,10 @@
                 "module": "./RootApp",
                 "routes": [
                     {
-                        "pathname": "/digital-roadmap/lifecycle"
+                        "pathname": "/roadmap/lifecycle"
                     },
                     {
-                        "pathname": "/digital-roadmap/roadmap"
+                        "pathname": "/roadmap/roadmap"
                     }
                 ]
             }

--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1187,10 +1187,10 @@
                 "module": "./RootApp",
                 "routes": [
                     {
-                        "pathname": "/roadmap/lifecycle"
+                        "pathname": "/insights/roadmap/lifecycle"
                     },
                     {
-                        "pathname": "/roadmap/roadmap"
+                        "pathname": "/insights/roadmap/roadmap"
                     }
                 ]
             }

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -535,6 +535,32 @@
       ]
     },
     {
+      "id": "roadmap",
+      "expandable": true,
+      "title": "Planning",
+      "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
+      "routes": [
+        {
+          "id": "lifeCycle",
+          "appId": "roadmap",
+          "title": "Life cycle",
+          "href": "/insights/digital-roadmap/lifecycle",
+          "product": "Red Hat Insights",
+          "alt_title": ["life cycle"],
+          "description": "Support status of operating systems and applications."
+        },
+        {
+          "id": "upcoming",
+          "appId": "roadmap",
+          "title": "Roadmap",
+          "href": "/insights/digital-roadmap/roadmap",
+          "product": "Red Hat Insights",
+          "alt_title": ["upcoming"],
+          "description": "Upcoming changes in RHEL and applications."
+        }
+      ]
+    },
+    {
       "title": "Business",
       "expandable": true,
       "routes": [

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -544,7 +544,7 @@
           "id": "lifeCycle",
           "appId": "roadmap",
           "title": "Life cycle",
-          "href": "/insights/digital-roadmap/lifecycle",
+          "href": "/insights/roadmap/lifecycle",
           "product": "Red Hat Insights",
           "alt_title": ["life cycle"],
           "description": "Support status of operating systems and applications."
@@ -553,7 +553,7 @@
           "id": "upcoming",
           "appId": "roadmap",
           "title": "Roadmap",
-          "href": "/insights/digital-roadmap/roadmap",
+          "href": "/insights/roadmap/roadmap",
           "product": "Red Hat Insights",
           "alt_title": ["upcoming"],
           "description": "Upcoming changes in RHEL and applications."


### PR DESCRIPTION
Roadmap is a new Insights application, our frontend repo is https://github.com/RedHatInsights/digital-roadmap-frontend/ .
We have our deployment ready and running in app-interface (service in insights/roadmap) but we are missing navigations to our application. I'm copying this from our chrome-service-backend development fork so we can see our application in stage preview.

I created this MR following the ConsoleDOT onboard guide: https://inscope.corp.redhat.com/docs/default/Component/consoledot-pages/containerized-frontends/migration/#step-5-b-specnavitems-section 