### PR TITLE
Allow CDN path attribute in modules definition.

### DIFF
--- a/static/modulesSchema.json
+++ b/static/modulesSchema.json
@@ -143,6 +143,9 @@
         "fullProfile": {
           "type": "boolean"
         },
+        "cdnPath": {
+          "type": "string"
+        },
         "config": {
           "$ref": "#/$defs/moduleConfig"
         },


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-38931
