### PR TITLE
Add digital roadmap config with feoReplacement

### DIFF
--- a/static/stable/stage/navigation/insights-navigation.json
+++ b/static/stable/stage/navigation/insights-navigation.json
@@ -485,6 +485,33 @@
       ]
     },
     {
+      "id": "roadmap",
+      "expandable": true,
+      "title": "Planning",
+      "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
+      "feoReplacement": "planning",
+      "routes": [
+        {
+          "id": "lifecycle",
+          "appId": "roadmap",
+          "title": "Lifecycle",
+          "href": "/insights/planning/lifecycle",
+          "product": "Red Hat Insights",
+          "alt_title": ["lifecycle"],
+          "description": "Support status of operating systems and applications."
+        },
+        {
+          "id": "upcoming",
+          "appId": "roadmap",
+          "title": "Roadmap",
+          "href": "/insights/planning/roadmap",
+          "product": "Red Hat Insights",
+          "alt_title": ["upcoming"],
+          "description": "Upcoming changes in RHEL and applications."
+        }
+      ]
+    },
+    {
       "title": "Business",
       "expandable": true,
       "routes": [


### PR DESCRIPTION
This PR adds the navigation config and feoReplacement flag for the migration from chrome-service to the frontend repository. The flag will allow for the bundle segment in the frontend.yaml of the frontend repository to be used for the navigation.
Documentation - https://github.com/RedHatInsights/chrome-service-backend/blob/main/docs/feo-migration-guide.md#4-mark-the-navigation-items-for-replacement-chrome-service-backend-repository