### PR TITLE
Update widget layout logic

### DIFF
--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -356,12 +356,11 @@ type WidgetConfiguration struct {
 }
 
 type ModuleFederationMetadata struct {
-	Scope       string               `json:"scope"`
-	Module      string               `json:"module"`
-	ImportName  string               `json:"importName,omitempty"`
-	FeatureFlag string               `json:"featureFlag,omitempty"`
-	Defaults    BaseWidgetDimensions `json:"defaults"`
-	Config      WidgetConfiguration  `json:"config"`
+	Scope      string               `json:"scope"`
+	Module     string               `json:"module"`
+	ImportName string               `json:"importName,omitempty"`
+	Defaults   BaseWidgetDimensions `json:"defaults"`
+	Config     WidgetConfiguration  `json:"config"`
 }
 
 type WidgetModuleFederationMapping map[AvailableWidgets]ModuleFederationMetadata

--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -356,12 +356,12 @@ type WidgetConfiguration struct {
 }
 
 type ModuleFederationMetadata struct {
-	Scope      string               `json:"scope"`
-	Module     string               `json:"module"`
-	ImportName string               `json:"importName,omitempty"`
-	Itless     bool                 `json:"itless,omitempty"`
-	Defaults   BaseWidgetDimensions `json:"defaults"`
-	Config     WidgetConfiguration  `json:"config"`
+	Scope       string               `json:"scope"`
+	Module      string               `json:"module"`
+	ImportName  string               `json:"importName,omitempty"`
+	FeatureFlag string               `json:"featureFlag,omitempty"`
+	Defaults    BaseWidgetDimensions `json:"defaults"`
+	Config      WidgetConfiguration  `json:"config"`
 }
 
 type WidgetModuleFederationMapping map[AvailableWidgets]ModuleFederationMetadata

--- a/rest/models/DashboardTemplate.go
+++ b/rest/models/DashboardTemplate.go
@@ -359,6 +359,7 @@ type ModuleFederationMetadata struct {
 	Scope      string               `json:"scope"`
 	Module     string               `json:"module"`
 	ImportName string               `json:"importName,omitempty"`
+	Itless     bool                 `json:"itless,omitempty"`
 	Defaults   BaseWidgetDimensions `json:"defaults"`
 	Config     WidgetConfiguration  `json:"config"`
 }

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -285,7 +285,6 @@ func FilterWidgetMapping(widgetMapping models.WidgetModuleFederationMapping) mod
 func GetWidgetMappings(w http.ResponseWriter, r *http.Request) {
 	var err error
 	var resp util.EntityResponse[models.WidgetModuleFederationMapping]
-	logrus.Errorln(err)
 
 	if featureflags.IsEnabled("chrome-service.filterWidgets.enable") {
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/RedHatInsights/chrome-service-backend/rest/featureflags"

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -322,6 +322,7 @@ func GetWidgetMappings(w http.ResponseWriter, r *http.Request) {
 
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{
 			Data: filteredWidgetMapping,
+		}
 	} else {
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{
 			Data: service.WidgetMapping,

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -275,7 +275,7 @@ func DecodeDashboardTemplate(w http.ResponseWriter, r *http.Request) {
 
 func FilterWidgetMapping(widgetMapping models.WidgetModuleFederationMapping) models.WidgetModuleFederationMapping {
 	for key, value := range widgetMapping {
-		if !value.Itless {
+		if !featureflags.IsEnabled(value.FeatureFlag) {
 			delete(widgetMapping, key)
 		}
 	}
@@ -288,9 +288,7 @@ func GetWidgetMappings(w http.ResponseWriter, r *http.Request) {
 	var resp util.EntityResponse[models.WidgetModuleFederationMapping]
 	logrus.Errorln(err)
 
-	logrus.Infoln("getting mappings")
-
-	if os.Getenv("FRONTEND_ENVIRONMENT") == "itless" {
+	if featureflags.IsEnabled("chrome-service.filterWidgets.enable") {
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{
 			Data: FilterWidgetMapping(service.WidgetMapping),
 		}

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -273,13 +273,26 @@ func DecodeDashboardTemplate(w http.ResponseWriter, r *http.Request) {
 	handleDashboardResponse[models.DashboardTemplate](resp, err, w)
 }
 
+func FilterWidgetMapping(widgetMapping models.WidgetModuleFederationMapping) models.WidgetModuleFederationMapping {
+	for key, value := range widgetMapping {
+		if !value.Itless {
+			delete(widgetMapping, key)
+		}
+	}
+
+	return widgetMapping
+}
+
 func GetWidgetMappings(w http.ResponseWriter, r *http.Request) {
 	var err error
 	var resp util.EntityResponse[models.WidgetModuleFederationMapping]
+	logrus.Errorln(err)
+
+	logrus.Infoln("getting mappings")
 
 	if os.Getenv("FRONTEND_ENVIRONMENT") == "itless" {
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{
-			Data: service.WidgetMappingItless,
+			Data: FilterWidgetMapping(service.WidgetMapping),
 		}
 	} else {
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{

--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -317,9 +317,11 @@ func GetWidgetMappings(w http.ResponseWriter, r *http.Request) {
 	var resp util.EntityResponse[models.WidgetModuleFederationMapping]
 
 	if featureflags.IsEnabled("chrome-service.filterWidgets.enable") {
+		filteredWidgetMapping := FilterWidgetMapping(service.WidgetMapping)
+		filteredWidgetMapping = FilterWidgetMappingHeaderLink(filteredWidgetMapping)
+
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{
-			Data: FilterWidgetMapping(service.WidgetMapping),
-		}
+			Data: filteredWidgetMapping,
 	} else {
 		resp = util.EntityResponse[models.WidgetModuleFederationMapping]{
 			Data: service.WidgetMapping,

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -62,6 +62,7 @@ var (
 		models.Rhel: models.ModuleFederationMetadata{
 			Scope:    "landing",
 			Module:   "./RhelWidget",
+			Itless:   true,
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.RhelIcon,
@@ -71,6 +72,7 @@ var (
 		models.OpenShift: models.ModuleFederationMetadata{
 			Scope:    "landing",
 			Module:   "./OpenShiftWidget",
+			Itless:   true,
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.OpenShiftIcon,
@@ -107,6 +109,7 @@ var (
 		models.RecentlyVisited: models.ModuleFederationMetadata{
 			Scope:    "landing",
 			Module:   "./RecentlyVisited",
+			Itless:   true,
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.HistoryIcon,
@@ -116,6 +119,7 @@ var (
 		models.FavoriteServices: models.ModuleFederationMetadata{
 			Scope:    "chrome",
 			Module:   "./DashboardFavorites",
+			Itless:   true,
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
@@ -129,6 +133,7 @@ var (
 		models.NotificationsEvents: models.ModuleFederationMetadata{
 			Scope:    "notifications",
 			Module:   "./DashboardWidget",
+			Itless:   true,
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
@@ -147,6 +152,7 @@ var (
 		models.LearningResources: models.ModuleFederationMetadata{
 			Scope:    "learningResources",
 			Module:   "./BookmarkedLearningResourcesWidget",
+			Itless:   true,
 			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
@@ -200,23 +206,13 @@ var (
 			},
 		},
 		models.Integrations: models.ModuleFederationMetadata{
-		Scope:    "sources",
-		Module:   "./IntegrationsWidget",
-		Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
-		Config: models.WidgetConfiguration{
-			HeaderLink: models.WidgetHeaderLink{
-				Title: "Explore integrations",
-				Href:  "/settings/integrations",
-			},
-			Icon:  models.IntegrationsIcon,
-			Title: "Integrations",
-			Permissions: []models.WidgetPermission{
-				models.WidgetPermission{
-					Method: models.FeatureFlag,
-					Args: []any{
-						"chrome-service.integrations-widget.enabled",
-						true,
-					},
+			Scope:    "sources",
+			Module:   "./IntegrationsWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
+			Config: models.WidgetConfiguration{
+				HeaderLink: models.WidgetHeaderLink{
+					Title: "Explore integrations",
+					Href:  "/settings/integrations",
 				},
 				Icon:  models.IntegrationsIcon,
 				Title: "Integrations",
@@ -235,75 +231,6 @@ var (
 						},
 					},
 				},
-			},
-		},
-	}
-	WidgetMappingItless models.WidgetModuleFederationMapping = models.WidgetModuleFederationMapping{
-		models.Rhel: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./RhelWidget",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			Config: models.WidgetConfiguration{
-				Icon:  models.RhelIcon,
-				Title: "Red Hat Enterprise Linux",
-			},
-		},
-		models.OpenShift: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./OpenShiftWidget",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			Config: models.WidgetConfiguration{
-				Icon:  models.OpenShiftIcon,
-				Title: "Red Hat OpenShift",
-			},
-		},
-		models.RecentlyVisited: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./RecentlyVisited",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
-			Config: models.WidgetConfiguration{
-				Icon:  models.HistoryIcon,
-				Title: "Recently visited",
-			},
-		},
-		models.FavoriteServices: models.ModuleFederationMetadata{
-			Scope:    "chrome",
-			Module:   "./DashboardFavorites",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
-			Config: models.WidgetConfiguration{
-				HeaderLink: models.WidgetHeaderLink{
-					Title: "View all services",
-					Href:  "/allservices",
-				},
-				Icon:  models.StarIcon,
-				Title: "My favorite services",
-			},
-		},
-		models.NotificationsEvents: models.ModuleFederationMetadata{
-			Scope:    "notifications",
-			Module:   "./DashboardWidget",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
-			Config: models.WidgetConfiguration{
-				HeaderLink: models.WidgetHeaderLink{
-					Title: "View event log",
-					Href:  "/settings/notifications/eventlog",
-				},
-				Icon:  models.BellIcon,
-				Title: "Events",
-				Permissions: []models.WidgetPermission{
-					models.WidgetPermission{
-						Method: models.OrgAdmin,
-					},
-				},
-			},
-		},
-		models.LearningResources: models.ModuleFederationMetadata{
-			Scope:    "learningResources",
-			Module:   "./BookmarkedLearningResourcesWidget",
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
-			Config: models.WidgetConfiguration{
-				Icon:  models.OutlinedBookmarkIcon,
-				Title: "Bookmarked learning resources",
 			},
 		},
 	}

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -24,110 +24,99 @@ var (
 	BaseTemplates models.BaseTemplates                 = models.BaseTemplates{}
 	WidgetMapping models.WidgetModuleFederationMapping = models.WidgetModuleFederationMapping{
 		models.ExploreCapabilities: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./ExploreCapabilities",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 3, 5, 10, 1),
-			FeatureFlag: "widget.exploreCapabilities.hidden",
+			Scope:    "landing",
+			Module:   "./ExploreCapabilities",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 3, 5, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.RocketIcon,
 				Title: "Explore capabilities",
 			},
 		},
 		models.Edge: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./EdgeWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.edge.hidden",
+			Scope:    "landing",
+			Module:   "./EdgeWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.EdgeIcon,
 				Title: "Edge Management",
 			},
 		},
 		models.ImageBuilder: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./ImageBuilderWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.images.hidden",
+			Scope:    "landing",
+			Module:   "./ImageBuilderWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.RhelIcon,
 				Title: "Image Builder",
 			},
 		},
 		models.Ansible: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./AnsibleWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.ansible.hidden",
+			Scope:    "landing",
+			Module:   "./AnsibleWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.AnsibleIcon,
 				Title: "Ansible Automation Platform",
 			},
 		},
 		models.Rhel: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./RhelWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.rhel.hidden",
+			Scope:    "landing",
+			Module:   "./RhelWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.RhelIcon,
 				Title: "Red Hat Enterprise Linux",
 			},
 		},
 		models.OpenShift: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./OpenShiftWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.openshift.hidden",
+			Scope:    "landing",
+			Module:   "./OpenShiftWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.OpenShiftIcon,
 				Title: "Red Hat OpenShift",
 			},
 		},
 		models.Quay: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./QuayWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.quay.hidden",
+			Scope:    "landing",
+			Module:   "./QuayWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.QuayIcon,
 				Title: "Quay.io",
 			},
 		},
 		models.Acs: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./AcsWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.acs.hidden",
+			Scope:    "landing",
+			Module:   "./AcsWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.ACSIcon,
 				Title: "Advanced Cluster Security",
 			},
 		},
 		models.OpenShiftAi: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./OpenShiftAiWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
-			FeatureFlag: "widget.openshiftAI.hidden",
+			Scope:    "landing",
+			Module:   "./OpenShiftAiWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.OpenShiftAiIcon,
 				Title: "Red Hat OpenShift AI",
 			},
 		},
 		models.RecentlyVisited: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./RecentlyVisited",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
-			FeatureFlag: "widget.recentlyVisited.hidden",
+			Scope:    "landing",
+			Module:   "./RecentlyVisited",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.HistoryIcon,
 				Title: "Recently visited",
 			},
 		},
 		models.FavoriteServices: models.ModuleFederationMetadata{
-			Scope:       "chrome",
-			Module:      "./DashboardFavorites",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
-			FeatureFlag: "widget.favoriteServices.hidden",
+			Scope:    "chrome",
+			Module:   "./DashboardFavorites",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "View all services",
@@ -138,10 +127,9 @@ var (
 			},
 		},
 		models.NotificationsEvents: models.ModuleFederationMetadata{
-			Scope:       "notifications",
-			Module:      "./DashboardWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
-			FeatureFlag: "widget.notificationsEvents.hidden",
+			Scope:    "notifications",
+			Module:   "./DashboardWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "View event log",
@@ -157,10 +145,9 @@ var (
 			},
 		},
 		models.LearningResources: models.ModuleFederationMetadata{
-			Scope:       "learningResources",
-			Module:      "./BookmarkedLearningResourcesWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
-			FeatureFlag: "widget.learningResources.hidden",
+			Scope:    "learningResources",
+			Module:   "./BookmarkedLearningResourcesWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title:       "View all",
@@ -172,10 +159,9 @@ var (
 			},
 		},
 		models.SupportCases: models.ModuleFederationMetadata{
-			Scope:       "landing",
-			Module:      "./SupportCaseWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
-			FeatureFlag: "widget.supportCases.hidden",
+			Scope:    "landing",
+			Module:   "./SupportCaseWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "Open a support case",
@@ -186,10 +172,9 @@ var (
 			},
 		},
 		models.Subscriptions: models.ModuleFederationMetadata{
-			Scope:       "subscriptionInventory",
-			Module:      "./SubscriptionsWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 4, 4, 10, 1),
-			FeatureFlag: "widget.subscriptions.hidden",
+			Scope:    "subscriptionInventory",
+			Module:   "./SubscriptionsWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 4, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "Manage subscriptions",
@@ -215,14 +200,23 @@ var (
 			},
 		},
 		models.Integrations: models.ModuleFederationMetadata{
-			Scope:       "sources",
-			Module:      "./IntegrationsWidget",
-			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
-			FeatureFlag: "widget.integrations.hidden",
-			Config: models.WidgetConfiguration{
-				HeaderLink: models.WidgetHeaderLink{
-					Title: "Explore integrations",
-					Href:  "/settings/integrations",
+		Scope:    "sources",
+		Module:   "./IntegrationsWidget",
+		Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
+		Config: models.WidgetConfiguration{
+			HeaderLink: models.WidgetHeaderLink{
+				Title: "Explore integrations",
+				Href:  "/settings/integrations",
+			},
+			Icon:  models.IntegrationsIcon,
+			Title: "Integrations",
+			Permissions: []models.WidgetPermission{
+				models.WidgetPermission{
+					Method: models.FeatureFlag,
+					Args: []any{
+						"chrome-service.integrations-widget.enabled",
+						true,
+					},
 				},
 				Icon:  models.IntegrationsIcon,
 				Title: "Integrations",
@@ -241,6 +235,75 @@ var (
 						},
 					},
 				},
+			},
+		},
+	}
+	WidgetMappingItless models.WidgetModuleFederationMapping = models.WidgetModuleFederationMapping{
+		models.Rhel: models.ModuleFederationMetadata{
+			Scope:    "landing",
+			Module:   "./RhelWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			Config: models.WidgetConfiguration{
+				Icon:  models.RhelIcon,
+				Title: "Red Hat Enterprise Linux",
+			},
+		},
+		models.OpenShift: models.ModuleFederationMetadata{
+			Scope:    "landing",
+			Module:   "./OpenShiftWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			Config: models.WidgetConfiguration{
+				Icon:  models.OpenShiftIcon,
+				Title: "Red Hat OpenShift",
+			},
+		},
+		models.RecentlyVisited: models.ModuleFederationMetadata{
+			Scope:    "landing",
+			Module:   "./RecentlyVisited",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
+			Config: models.WidgetConfiguration{
+				Icon:  models.HistoryIcon,
+				Title: "Recently visited",
+			},
+		},
+		models.FavoriteServices: models.ModuleFederationMetadata{
+			Scope:    "chrome",
+			Module:   "./DashboardFavorites",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
+			Config: models.WidgetConfiguration{
+				HeaderLink: models.WidgetHeaderLink{
+					Title: "View all services",
+					Href:  "/allservices",
+				},
+				Icon:  models.StarIcon,
+				Title: "My favorite services",
+			},
+		},
+		models.NotificationsEvents: models.ModuleFederationMetadata{
+			Scope:    "notifications",
+			Module:   "./DashboardWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
+			Config: models.WidgetConfiguration{
+				HeaderLink: models.WidgetHeaderLink{
+					Title: "View event log",
+					Href:  "/settings/notifications/eventlog",
+				},
+				Icon:  models.BellIcon,
+				Title: "Events",
+				Permissions: []models.WidgetPermission{
+					models.WidgetPermission{
+						Method: models.OrgAdmin,
+					},
+				},
+			},
+		},
+		models.LearningResources: models.ModuleFederationMetadata{
+			Scope:    "learningResources",
+			Module:   "./BookmarkedLearningResourcesWidget",
+			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
+			Config: models.WidgetConfiguration{
+				Icon:  models.OutlinedBookmarkIcon,
+				Title: "Bookmarked learning resources",
 			},
 		},
 	}

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -60,20 +60,20 @@ var (
 			},
 		},
 		models.Rhel: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./RhelWidget",
-			Itless:   true,
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			Scope:       "landing",
+			Module:      "./RhelWidget",
+			FeatureFlag: "widget.rhel.enable",
+			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.RhelIcon,
 				Title: "Red Hat Enterprise Linux",
 			},
 		},
 		models.OpenShift: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./OpenShiftWidget",
-			Itless:   true,
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
+			Scope:       "landing",
+			Module:      "./OpenShiftWidget",
+			FeatureFlag: "widget.openshift.enable",
+			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.OpenShiftIcon,
 				Title: "Red Hat OpenShift",
@@ -107,20 +107,20 @@ var (
 			},
 		},
 		models.RecentlyVisited: models.ModuleFederationMetadata{
-			Scope:    "landing",
-			Module:   "./RecentlyVisited",
-			Itless:   true,
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
+			Scope:       "landing",
+			Module:      "./RecentlyVisited",
+			FeatureFlag: "widget.recentlyVisited.enable",
+			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 7, 10, 1),
 			Config: models.WidgetConfiguration{
 				Icon:  models.HistoryIcon,
 				Title: "Recently visited",
 			},
 		},
 		models.FavoriteServices: models.ModuleFederationMetadata{
-			Scope:    "chrome",
-			Module:   "./DashboardFavorites",
-			Itless:   true,
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
+			Scope:       "chrome",
+			Module:      "./DashboardFavorites",
+			FeatureFlag: "widget.favoriteServices.enable",
+			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 6, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "View all services",
@@ -131,10 +131,10 @@ var (
 			},
 		},
 		models.NotificationsEvents: models.ModuleFederationMetadata{
-			Scope:    "notifications",
-			Module:   "./DashboardWidget",
-			Itless:   true,
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
+			Scope:       "notifications",
+			Module:      "./DashboardWidget",
+			FeatureFlag: "widget.notifications.enabled",
+			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title: "View event log",
@@ -150,10 +150,10 @@ var (
 			},
 		},
 		models.LearningResources: models.ModuleFederationMetadata{
-			Scope:    "learningResources",
-			Module:   "./BookmarkedLearningResourcesWidget",
-			Itless:   true,
-			Defaults: models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
+			Scope:       "learningResources",
+			Module:      "./BookmarkedLearningResourcesWidget",
+			FeatureFlag: "widget.learningResources.enable",
+			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 2, 4, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{
 					Title:       "View all",

--- a/rest/service/dashboardTemplate.go
+++ b/rest/service/dashboardTemplate.go
@@ -133,7 +133,7 @@ var (
 		models.NotificationsEvents: models.ModuleFederationMetadata{
 			Scope:       "notifications",
 			Module:      "./DashboardWidget",
-			FeatureFlag: "widget.notifications.enabled",
+			FeatureFlag: "widget.notifications.enable",
 			Defaults:    models.BaseWidgetDimensions.InitDimensions(models.BaseWidgetDimensions{}, 1, 3, 10, 1),
 			Config: models.WidgetConfiguration{
 				HeaderLink: models.WidgetHeaderLink{


### PR DESCRIPTION
Create a new optional boolean within the ModuleFederationMetadata that specifies the widget should be used in an itless environment. This makes every widget off by default rather than on, making management of the widgets easier.

It also moves the check to the FRONTEND_ENVIRONMENT var rather than a feature flag