### PR TITLE
Add CDN path to landing module.

### DIFF
--- a/static/beta/itless/modules/fed-modules.json
+++ b/static/beta/itless/modules/fed-modules.json
@@ -2,6 +2,7 @@
     "landing": {
         "manifestLocation": "/apps/landing/fed-mods.json",
         "defaultDocumentTitle": "Hybrid Cloud Console Home",
+        "cdnPath": "/apps/landing/",
         "modules": [
             {
                 "id": "landing",

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -3,6 +3,7 @@
     "landing": {
         "manifestLocation": "/apps/landing/fed-mods.json",
         "defaultDocumentTitle": "Hybrid Cloud Console Home",
+        "cdnPath": "/apps/landing/",
         "modules": [
             {
                 "id": "landing",

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -3,6 +3,7 @@
   "landing": {
       "manifestLocation": "/apps/landing/fed-mods.json",
       "defaultDocumentTitle": "Hybrid Cloud Console Home",
+      "cdnPath": "/apps/landing/",
       "isFedramp": true,
       "modules": [
           {


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-39403

Preparation to consuming a landing page universal build used on multiple platforms.