### PR TITLE
Mark user preferences bundle as fully onboarded.

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -232,3 +232,6 @@ parameters:
 - description: Maximum number of recently used workspaces that the Chrome back end will store in the database for each user.
   name: RECENTLY_USED_WORKSPACES_MAX_SAVED
   value: '10'
+- description: Bundles navigation fully onboarded to FEO
+  name: FEO_BUNDLES_ONBOARDED_IDS
+  value: '["user-preferences"]'


### PR DESCRIPTION
To test the integration we first use local clowdapp. Once tested, we can start moving the variables value to app interface.

Part of https://issues.redhat.com/browse/RHCLOUD-39259

## Summary by Sourcery

Deployment:
- Add a new parameter to specify fully onboarded bundle IDs for FEO (Front-End Onboarding)