### PR TITLE
update intercom config to include insights

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,38 @@ type IntercomConfig struct {
 	automationAnalytics_dev string
 	dbaas                   string
 	dbaas_dev               string
+	activationKeys          string
+	activationKeys_dev      string
+	advisor                 string
+	advisor_dev             string
+	compliance              string
+	compliance_dev          string
+	connector               string
+	connector_dev           string
+	contentSources          string
+	contentSources_dev      string
+	dashboard               string
+	dashboard_dev           string
+	imageBuilder            string
+	imageBuilder_dev        string
+	inventory               string
+	inventory_dev           string
+	malware                 string
+	malware_dev             string
+	patch                   string
+	patch_dev               string
+	policies                string
+	policies_dev            string
+	registration            string
+	registration_dev        string
+	remediations            string
+	remediations_dev        string
+	ros                     string
+	ros_dev                 string
+	tasks                   string
+	tasks_dev               string
+	vulnerability           string
+	vulnerability_dev       string
 }
 
 type FeatureFlagsConfig struct {
@@ -224,6 +256,38 @@ func init() {
 		hacCore:                 os.Getenv("INTERCOM_HAC_CORE"),
 		dbaas:                   os.Getenv("INTERCOM_DBAAS"),
 		dbaas_dev:               os.Getenv("INTERCOM_DBAAS_DEV"),
+		activationKeys:          os.Getenv("INTERCOM_INSIGHTS"),
+		activationKeys_dev:      os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		advisor:                 os.Getenv("INTERCOM_INSIGHTS"),
+		advisor_dev:             os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		compliance:              os.Getenv("INTERCOM_INSIGHTS"),
+		compliance_dev:          os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		connector:               os.Getenv("INTERCOM_INSIGHTS"),
+		connector_dev:           os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		contentSources:          os.Getenv("INTERCOM_INSIGHTS"),
+		contentSources_dev:      os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		dashboard:               os.Getenv("INTERCOM_INSIGHTS"),
+		dashboard_dev:           os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		imageBuilder:            os.Getenv("INTERCOM_INSIGHTS"),
+		imageBuilder_dev:        os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		inventory:               os.Getenv("INTERCOM_INSIGHTS"),
+		inventory_dev:           os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		malware:                 os.Getenv("INTERCOM_INSIGHTS"),
+		malware_dev:             os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		patch:                   os.Getenv("INTERCOM_INSIGHTS"),
+		patch_dev:               os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		policies:                os.Getenv("INTERCOM_INSIGHTS"),
+		policies_dev:            os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		registration:            os.Getenv("INTERCOM_INSIGHTS"),
+		registration_dev:        os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		remediations:            os.Getenv("INTERCOM_INSIGHTS"),
+		remediations_dev:        os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		ros:                     os.Getenv("INTERCOM_INSIGHTS"),
+		ros_dev:                 os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		tasks:                   os.Getenv("INTERCOM_INSIGHTS"),
+		tasks_dev:               os.Getenv("INTERCOM_INSIGHTS_DEV"),
+		vulnerability:           os.Getenv("INTERCOM_INSIGHTS"),
+		vulnerability_dev:       os.Getenv("INTERCOM_INSIGHTS_DEV"),
 	}
 
 	options.DebugConfig = DebugConfig{

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -151,6 +151,16 @@ objects:
               secretKeyRef:
                 name: chrome-service-backend
                 key: INTERCOM_DBAAS_DEV
+          - name: INTERCOM_INSIGHTS
+            valueFrom:
+              secretKeyRef:
+                name: chrome-service-backend
+                key: INTERCOM_INSIGHTS
+          - name: INTERCOM_INSIGHTS_DEV
+            valueFrom:
+              secretKeyRef:
+                name: chrome-service-backend
+                key: INTERCOM_INSIGHTS_DEV
           - name: SEARCH_CLIENT_SECRET_PROD
             valueFrom:
               secretKeyRef:
@@ -193,6 +203,8 @@ objects:
       SEARCH_CLIENT_SECRET_STAGE: dGVzdFZhbHVl
       INTERCOM_DBAAS: dGVzdFZhbHVl
       INTERCOM_DBAAS_DEV: dGVzdFZhbHVl
+      INTERCOM_INSIGHTS: dGVzdFZhbHVl
+      INTERCOM_INSIGHTS_DEV: dGVzdFZhbHVl
       DEBUG_FAVORITES_ACCOUNT_1: OTk5
     type: Opaque
 

--- a/rest/service/identity.go
+++ b/rest/service/identity.go
@@ -34,6 +34,22 @@ const (
 	AutomationHub       IntercomApp = "automationHub"
 	AutomationAnalytics IntercomApp = "automationAnalytics"
 	DBAAS               IntercomApp = "dbaas"
+	ActivationKeys      IntercomApp = "activationKeys"
+	Advisor             IntercomApp = "advisor"
+	Compliance          IntercomApp = "compliance"
+	Connector           IntercomApp = "connector"
+	ContentSources      IntercomApp = "contentSources"
+	Dashboard           IntercomApp = "dashboard"
+	ImageBuilder        IntercomApp = "imageBuilder"
+	Inventory           IntercomApp = "inventory"
+	Malware             IntercomApp = "malware"
+	Patch               IntercomApp = "patch"
+	Policies            IntercomApp = "policies"
+	Registration        IntercomApp = "registration"
+	Remediations        IntercomApp = "remediations"
+	Ros                 IntercomApp = "ros"
+	Tasks               IntercomApp = "tasks"
+	Vulnerability       IntercomApp = "vulnerability"
 )
 
 func debugFavoritesIdentity(userId string) {
@@ -47,7 +63,7 @@ func debugFavoritesIdentity(userId string) {
 
 func (ib IntercomApp) IsValidApp() error {
 	switch ib {
-	case OpenShift, HacCore, Ansible, Acs, AnsibleDashboard, AutomationHub, AutomationAnalytics, DBAAS:
+	case OpenShift, HacCore, Ansible, Acs, AnsibleDashboard, AutomationHub, AutomationAnalytics, DBAAS, ActivationKeys, Advisor, Compliance, Connector, ContentSources, Dashboard, ImageBuilder, Inventory, Malware, Patch, Policies, Registration, Remediations, Ros, Tasks, Vulnerability:
 		return nil
 	}
 

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -153,6 +153,9 @@
       ]
     },
     "connector": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/connector/fed-mods.json",
         "defaultDocumentTitle": "Remote Host Configuration | Settings",
         "config": {
@@ -227,6 +230,9 @@
         "modules": []
     },
     "dashboard": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/dashboard/fed-mods.json",
         "isFedramp": true,
         "modules": [
@@ -245,6 +251,9 @@
         ]
     },
     "advisor": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/advisor/fed-mods.json",
         "config": {
           "supportCaseData": {
@@ -269,6 +278,9 @@
         ]
     },
     "malware": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/malware/fed-mods.json",
         "config": {
             "supportCaseData": {
@@ -323,6 +335,9 @@
         ]
     },
     "inventory": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/inventory/fed-mods.json",
         "config": {
             "supportCaseData": {
@@ -347,6 +362,9 @@
         ]
     },
     "vulnerability": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/vulnerability/fed-mods.json",
         "isFedramp": true,
         "config": {
@@ -368,6 +386,9 @@
         ]
     },
     "compliance": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/compliance/fed-mods.json",
         "isFedramp": true,
         "config": {
@@ -389,6 +410,9 @@
         ]
     },
     "policies": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/policies/fed-mods.json",
         "config": {
             "supportCaseData": {
@@ -413,6 +437,9 @@
         ]
     },
     "patch": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/patch/fed-mods.json",
         "isFedramp": true,
         "config": {
@@ -473,6 +500,9 @@
         ]
     },
     "activationKeys": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/activation-keys/fed-mods.json",
         "modules": [
             {
@@ -536,6 +566,9 @@
         ]
     },
     "ros": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/ros/fed-mods.json",
         "config": {
             "supportCaseData": {
@@ -556,6 +589,9 @@
         ]
     },
     "registration": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/registration/fed-mods.json",
         "modules": [
             {
@@ -573,6 +609,9 @@
         ]
     },
     "remediations": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/remediations/fed-mods.json",
         "config": {
             "supportCaseData": {
@@ -597,6 +636,9 @@
         ]
     },
     "tasks": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/tasks/fed-mods.json",
         "config": {
             "supportCaseData": {
@@ -903,6 +945,9 @@
         ]
     },
     "contentSources": {
+        "analytics": {
+            "APIKey": "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        },
         "manifestLocation": "/apps/content-sources/fed-mods.json",
         "defaultDocumentTitle": "Repositories",
         "modules": [

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -175,6 +175,9 @@
       ]
   },
   "connector": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/connector/fed-mods.json",
       "defaultDocumentTitle": "Remote Host Configuration | Settings",
       "config": {
@@ -259,6 +262,9 @@
         ]
   },
   "dashboard": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/dashboard/fed-mods.json",
       "isFedramp": true,
       "modules": [
@@ -277,6 +283,9 @@
       ]
   },
   "advisor": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/advisor/fed-mods.json",
       "isFedramp": true,
       "config": {
@@ -335,6 +344,9 @@
       ]
   },
   "inventory": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/inventory/fed-mods.json",
       "config": {
         "supportCaseData": {
@@ -359,6 +371,9 @@
       ]
   },
   "vulnerability": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/vulnerability/fed-mods.json",
       "isFedramp": true,
       "config": {
@@ -380,6 +395,9 @@
       ]
   },
   "compliance": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/compliance/fed-mods.json",
       "isFedramp": true,
       "config": {
@@ -401,6 +419,9 @@
       ]
   },
   "policies": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/policies/fed-mods.json",
       "config": {
         "supportCaseData": {
@@ -425,6 +446,9 @@
       ]
   },
   "patch": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/patch/fed-mods.json",
       "isFedramp": true,
       "config": {
@@ -502,6 +526,9 @@
     ]
   },
   "activationKeys": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/activation-keys/fed-mods.json",
       "modules": [
           {
@@ -544,6 +571,9 @@
       ]
   },
   "ros": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/ros/fed-mods.json",
       "config": {
         "supportCaseData": {
@@ -564,6 +594,9 @@
       ]
   },
   "registration": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/registration/fed-mods.json",
       "modules": [
           {
@@ -581,6 +614,9 @@
       ]
   },
   "remediations": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/remediations/fed-mods.json",
       "config": {
         "supportCaseData": {
@@ -605,6 +641,9 @@
       ]
   },
   "tasks": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/tasks/fed-mods.json",
       "config": {
           "supportCaseData": {
@@ -893,6 +932,9 @@
       ]
   },
   "malware": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/malware/fed-mods.json",
       "isFedramp": true,
       "config": {
@@ -1042,6 +1084,9 @@
       ]
   },
   "contentSources": {
+    "analytics": {
+        "APIKey": "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
+    },
       "manifestLocation": "/apps/content-sources/fed-mods.json",
       "defaultDocumentTitle": "Repositories",
       "modules": [


### PR DESCRIPTION
[RHCLOUD-37947](https://issues.redhat.com/browse/RHCLOUD-37947)

- Update the Intercom Configuration to include Insights modules

## Summary by Sourcery

Configure Intercom integration for multiple Insights application modules.

Enhancements:
- Define configuration settings and constants for various Insights modules (e.g., Advisor, Compliance, Inventory).
- Read Insights module configurations from `INTERCOM_INSIGHTS` and `INTERCOM_INSIGHTS_DEV` environment variables.
- Validate new Insights modules as valid Intercom applications.

Deployment:
- Add `INTERCOM_INSIGHTS` and `INTERCOM_INSIGHTS_DEV` environment variables to the deployment configuration.