### PR TITLE
Add org admin perms for user access

### DIFF
--- a/static/beta/prod/navigation/iam-navigation.json
+++ b/static/beta/prod/navigation/iam-navigation.json
@@ -60,6 +60,7 @@
             "identity management",
             "users",
             "roles",
+            "groups",
             "permissions",
             "access",
             "admin",

--- a/static/beta/prod/navigation/iam-navigation.json
+++ b/static/beta/prod/navigation/iam-navigation.json
@@ -33,6 +33,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.overview", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"
@@ -42,6 +45,11 @@
           "appId": "rbac",
           "title": "Users",
           "href": "/iam/user-access/users",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management",
           "description": "Manage your organization's role-based access control (RBAC) to services.",
@@ -52,7 +60,6 @@
             "identity management",
             "users",
             "roles",
-            "groups",
             "permissions",
             "access",
             "admin",
@@ -68,14 +75,24 @@
           "appId": "rbac",
           "title": "Roles",
           "href": "/iam/user-access/roles",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "product": "Identity & Access Management"
         },
         {
           "id": "groups",
           "appId": "rbac",
           "title": "Groups",
-          "icon": "PlaceholderIcon",
           "href": "/iam/user-access/groups",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
+          "icon": "PlaceholderIcon",
           "product": "Identity & Access Management"
         },
         {
@@ -88,6 +105,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.workspaces-list", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"

--- a/static/beta/stage/navigation/iam-navigation.json
+++ b/static/beta/stage/navigation/iam-navigation.json
@@ -32,6 +32,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.overview", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"
@@ -41,6 +44,11 @@
           "appId": "rbac",
           "title": "Users",
           "href": "/iam/user-access/users",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management",
           "description": "Manage your organization's role-based access control (RBAC) to services.",
@@ -51,7 +59,6 @@
             "identity management",
             "users",
             "roles",
-            "groups",
             "permissions",
             "access",
             "admin",
@@ -67,14 +74,24 @@
           "appId": "rbac",
           "title": "Roles",
           "href": "/iam/user-access/roles",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "product": "Identity & Access Management"
         },
         {
           "id": "groups",
           "appId": "rbac",
           "title": "Groups",
-          "icon": "PlaceholderIcon",
           "href": "/iam/user-access/groups",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
+          "icon": "PlaceholderIcon",
           "product": "Identity & Access Management"
         },
         {
@@ -87,6 +104,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.workspaces-list", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"

--- a/static/beta/stage/navigation/iam-navigation.json
+++ b/static/beta/stage/navigation/iam-navigation.json
@@ -59,6 +59,7 @@
             "identity management",
             "users",
             "roles",
+            "groups",
             "permissions",
             "access",
             "admin",

--- a/static/stable/prod/navigation/iam-navigation.json
+++ b/static/stable/prod/navigation/iam-navigation.json
@@ -32,6 +32,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.overview", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"
@@ -41,6 +44,11 @@
           "appId": "rbac",
           "title": "Users",
           "href": "/iam/user-access/users",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management",
           "description": "Manage your organization's role-based access control (RBAC) to services.",
@@ -51,7 +59,6 @@
             "identity management",
             "users",
             "roles",
-            "groups",
             "permissions",
             "access",
             "admin",
@@ -67,6 +74,11 @@
           "appId": "rbac",
           "title": "Roles",
           "href": "/iam/user-access/roles",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "product": "Identity & Access Management"
         },
         {
@@ -74,6 +86,11 @@
           "appId": "rbac",
           "title": "Groups",
           "href": "/iam/user-access/groups",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management"
         },
@@ -87,6 +104,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.workspaces-list", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"

--- a/static/stable/prod/navigation/iam-navigation.json
+++ b/static/stable/prod/navigation/iam-navigation.json
@@ -59,6 +59,7 @@
             "identity management",
             "users",
             "roles",
+            "groups",
             "permissions",
             "access",
             "admin",

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -61,6 +61,7 @@
             "identity management",
             "users",
             "roles",
+            "groups",
             "permissions",
             "access",
             "admin",

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -34,6 +34,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.overview", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"
@@ -43,6 +46,11 @@
           "appId": "rbac",
           "title": "Users",
           "href": "/iam/user-access/users",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management",
           "description": "Manage your organization's role-based access control (RBAC) to services.",
@@ -68,6 +76,11 @@
           "appId": "rbac",
           "title": "Roles",
           "href": "/iam/user-access/roles",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "product": "Identity & Access Management"
         },
         {
@@ -75,6 +88,11 @@
           "appId": "rbac",
           "title": "Groups",
           "href": "/iam/user-access/groups",
+          "permissions": [
+            {
+              "method": "isOrgAdmin"
+            }
+          ],
           "icon": "PlaceholderIcon",
           "product": "Identity & Access Management"
         },
@@ -88,6 +106,9 @@
             {
               "method": "featureFlag",
               "args": ["platform.rbac.workspaces-list", true]
+            },
+            {
+              "method": "isOrgAdmin"
             }
           ],
           "product": "Identity & Access Management"


### PR DESCRIPTION
For [RHCLOUD-38987](https://issues.redhat.com/browse/RHCLOUD-38987). Users were able to access pages they did not have perms for creating a confusing workflow.

## Summary by Sourcery

Enhancements:
- Updated IAM navigation configuration to enforce proper access controls