### PR TITLE
Update Cost Management nav links

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -120,6 +120,19 @@
               "subtitle": "Red Hat Insights for OpenShift"
             },
             {
+              "id": "systems",
+              "appId": "costManagement",
+              "title": "Systems",
+              "href": "/openshift/cost-management/systems",
+              "product": "Red Hat Cost Management",
+              "permissions": [
+                {
+                  "method": "featureFlag",
+                  "args": ["cost-management.ui.systems", true]
+                }
+              ]
+            },
+            {
               "id": "costManagementOptimizations",
               "appId": "costManagement",
               "title": "Optimizations",
@@ -148,30 +161,10 @@
               "product": "Red Hat Cost Management"
             },
             {
-              "id": "ibmCloud",
-              "appId": "costManagement",
-              "title": "IBM Cloud",
-              "href": "/openshift/cost-management/ibm",
-              "product": "Red Hat Cost Management",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["cost-management.ui.ibm", true]
-                }
-              ]
-            },
-            {
               "id": "microsoftAzure",
               "appId": "costManagement",
               "title": "Microsoft Azure",
               "href": "/openshift/cost-management/azure",
-              "product": "Red Hat Cost Management"
-            },
-            {
-              "id": "oracleCloudInfrastructure",
-              "appId": "costManagement",
-              "title": "Oracle Cloud Infrastructure",
-              "href": "/openshift/cost-management/oci",
               "product": "Red Hat Cost Management"
             },
             {

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -119,6 +119,19 @@
               "subtitle": "Red Hat Insights for OpenShift"
             },
             {
+              "id": "systems",
+              "appId": "costManagement",
+              "title": "Systems",
+              "href": "/openshift/cost-management/systems",
+              "product": "Red Hat Cost Management",
+              "permissions": [
+                {
+                  "method": "featureFlag",
+                  "args": ["cost-management.ui.systems", true]
+                }
+              ]
+            },
+            {
               "id": "costManagementOptimizations",
               "appId": "costManagement",
               "title": "Optimizations",
@@ -147,30 +160,10 @@
               "product": "Red Hat Cost Management"
             },
             {
-              "id": "ibmCloud",
-              "appId": "costManagement",
-              "title": "IBM Cloud",
-              "href": "/openshift/cost-management/ibm",
-              "product": "Red Hat Cost Management",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["cost-management.ui.ibm", true]
-                }
-              ]
-            },
-            {
               "id": "microsoftAzure",
               "appId": "costManagement",
               "title": "Microsoft Azure",
               "href": "/openshift/cost-management/azure",
-              "product": "Red Hat Cost Management"
-            },
-            {
-              "id": "oracleCloudInfrastructure",
-              "appId": "costManagement",
-              "title": "Oracle Cloud Infrastructure",
-              "href": "/openshift/cost-management/oci",
               "product": "Red Hat Cost Management"
             },
             {

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -132,6 +132,19 @@
               "subtitle": "Red Hat Insights for OpenShift"
             },
             {
+              "id": "systems",
+              "appId": "costManagement",
+              "title": "Systems",
+              "href": "/openshift/cost-management/systems",
+              "product": "Red Hat Cost Management",
+              "permissions": [
+                {
+                  "method": "featureFlag",
+                  "args": ["cost-management.ui.systems", true]
+                }
+              ]
+            },
+            {
               "id": "costManagementOptimizations",
               "appId": "costManagement",
               "title": "Optimizations",
@@ -160,30 +173,10 @@
               "product": "Red Hat Cost Management"
             },
             {
-              "id": "ibmCloud",
-              "appId": "costManagement",
-              "title": "IBM Cloud",
-              "href": "/openshift/cost-management/ibm",
-              "product": "Red Hat Cost Management",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["cost-management.ui.ibm", true]
-                }
-              ]
-            },
-            {
               "id": "microsoftAzure",
               "appId": "costManagement",
               "title": "Microsoft Azure",
               "href": "/openshift/cost-management/azure",
-              "product": "Red Hat Cost Management"
-            },
-            {
-              "id": "oracleCloudInfrastructure",
-              "appId": "costManagement",
-              "title": "Oracle Cloud Infrastructure",
-              "href": "/openshift/cost-management/oci",
               "product": "Red Hat Cost Management"
             },
             {

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -131,6 +131,19 @@
               "subtitle": "Red Hat Insights for OpenShift"
             },
             {
+              "id": "systems",
+              "appId": "costManagement",
+              "title": "Systems",
+              "href": "/openshift/cost-management/systems",
+              "product": "Red Hat Cost Management",
+              "permissions": [
+                {
+                  "method": "featureFlag",
+                  "args": ["cost-management.ui.systems", true]
+                }
+              ]
+            },
+            {
               "id": "costManagementOptimizations",
               "appId": "costManagement",
               "title": "Optimizations",
@@ -159,30 +172,10 @@
               "product": "Red Hat Cost Management"
             },
             {
-              "id": "ibmCloud",
-              "appId": "costManagement",
-              "title": "IBM Cloud",
-              "href": "/openshift/cost-management/ibm",
-              "product": "Red Hat Cost Management",
-              "permissions": [
-                {
-                  "method": "featureFlag",
-                  "args": ["cost-management.ui.ibm", true]
-                }
-              ]
-            },
-            {
               "id": "microsoftAzure",
               "appId": "costManagement",
               "title": "Microsoft Azure",
               "href": "/openshift/cost-management/azure",
-              "product": "Red Hat Cost Management"
-            },
-            {
-              "id": "oracleCloudInfrastructure",
-              "appId": "costManagement",
-              "title": "Oracle Cloud Infrastructure",
-              "href": "/openshift/cost-management/oci",
               "product": "Red Hat Cost Management"
             },
             {


### PR DESCRIPTION
Replace Cost Management's OCI and IBM navigation links with “Systems”.

Fixes:
https://issues.redhat.com/browse/COST-6277
https://issues.redhat.com/browse/COST-5718
https://issues.redhat.com/browse/COST-6214

## Summary by Sourcery

Chores:
- Removed OCI navigation link across multiple environment configurations