### PR TITLE
Fix WS list permissions list to inventory groups read

### DIFF
--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -109,7 +109,8 @@
               "args": ["platform.rbac.workspaces-list", true]
             },
             {
-              "method": "isOrgAdmin"
+              "method": "loosePermissions",
+              "args": [["inventory:groups:read"]]
             }
           ],
           "product": "Identity & Access Management"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Corrected permissions for workspace list access in inventory groups