### PR TITLE
Remove Roadmap search entry

### DIFF
--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -997,41 +997,5 @@
           "Third Party"
         ]
       }
-  ]},
-  {
-    "id": "roadmap",
-    "links": [
-      {
-        "custom": true,
-        "id": "roadmap.lifecycle",
-        "href": "/insights/roadmap/lifecycle",
-        "title": "Lifecycle",
-        "description": "View tailored life cycle data for Red Hat Enterprise Linux and RHEL application streams.",
-        "alt_title": [
-          "planning",
-          "RHEL versions",
-          "rhel versions",
-          "Life cycle",
-          "life cycle",
-          "app stream",
-          "app streams",
-          "application stream",
-          "application streams"
-        ]
-      },
-      {
-        "custom": true,
-        "id": "roadmap.roadmap",
-        "href": "/insights/roadmap/roadmap",
-        "title": "Roadmap",
-        "description": "View the latest updates on upcoming Red Hat Enterprise Linux features, tailored to your systems.",
-        "alt_title": [
-          "planning",
-          "RHEL versions",
-          "rhel versions",
-          "Roadmap",
-          "roadmap"
-        ]
-      }
   ]}
 ]


### PR DESCRIPTION
Remove the entry as it's present in frontend.yml file of the project: 
https://github.com/RedHatInsights/digital-roadmap-frontend/blob/main/deploy/frontend.yaml

## Summary by Sourcery

Chores:
- Remove redundant Roadmap search entry from static-services-entries.json