### PR TITLE
Add feoReplacement for api-docs and widget-layout

### DIFF
--- a/static/stable/stage/navigation/docs-navigation.json
+++ b/static/stable/stage/navigation/docs-navigation.json
@@ -6,7 +6,8 @@
             "id": "apiDocumentation",
             "title": "API Documentation",
             "appId": "apiDocs",
-            "href": "/docs/api"
+            "href": "/docs/api",
+            "feoReplacement": "api-docs"
         },
         {
             "title": "Product Documentation",

--- a/static/stable/stage/navigation/staging-navigation.json
+++ b/static/stable/stage/navigation/staging-navigation.json
@@ -13,7 +13,8 @@
             "id": "widget-layout",
             "title": "Widget layour",
             "appId": "widget-layout",
-            "href": "/staging/widget-layout"
+            "href": "/staging/widget-layout",
+            "feoReplacement": "widgetLayout"
         },
         {
             "id": "global-learning-resources-page",


### PR DESCRIPTION
Adding `feoReplacement` for api-docs and widget-layout now that https://github.com/RedHatInsights/api-frontend/pull/746 and https://github.com/RedHatInsights/widget-layout/pull/161 have been merged

## Summary by Sourcery

Enhancements:
- Include feoReplacement links for api-docs and widget-layout in docs-navigation.json and staging-navigation.json