### PR TITLE
OCMUI-3317: Add ACM and Operators to OpenShift's left navigation

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -190,6 +190,14 @@
       "title": "Products",
       "navItems": [
         {
+          "id": "acm",
+          "appId": "openshift",
+          "description": "Manage, govern, and secure multiple Kubernetes clusters across hybrid and multicloud environments.",
+          "title": "Advanced Cluster Management",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec54aa3535cb70ab8c02996"
+        },
+        {
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
@@ -257,6 +265,13 @@
           "title": "OpenShift Virtualization",
           "isExternal": true,
           "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
+        },
+        {
+          "id": "operators",
+          "appId": "openshift",
+          "description": "Check out the latest recommended operators.",
+          "title": "Operators",
+          "href": "/openshift/overview#recommended-operators"
         }
       ]
     },

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -189,6 +189,14 @@
       "title": "Products",
       "navItems": [
         {
+          "id": "acm",
+          "appId": "openshift",
+          "description": "Manage, govern, and secure multiple Kubernetes clusters across hybrid and multicloud environments.",
+          "title": "Advanced Cluster Management",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec54aa3535cb70ab8c02996"
+        },
+        {
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
@@ -256,6 +264,13 @@
           "title": "OpenShift Virtualization",
           "isExternal": true,
           "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
+        },
+        {
+          "id": "operators",
+          "appId": "openshift",
+          "description": "Check out the latest recommended operators.",
+          "title": "Operators",
+          "href": "/openshift/overview#recommended-operators"
         }
       ]
     },

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -202,6 +202,14 @@
       "title": "Products",
       "navItems": [
         {
+          "id": "acm",
+          "appId": "openshift",
+          "description": "Manage, govern, and secure multiple Kubernetes clusters across hybrid and multicloud environments.",
+          "title": "Advanced Cluster Management",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec54aa3535cb70ab8c02996"
+        },
+        {
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
@@ -269,6 +277,13 @@
           "title": "OpenShift Virtualization",
           "isExternal": true,
           "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
+        },
+        {
+          "id": "operators",
+          "appId": "openshift",
+          "description": "Check out the latest recommended operators.",
+          "title": "Operators",
+          "href": "/openshift/overview#recommended-operators"
         }
       ]
     },

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -201,6 +201,14 @@
       "title": "Products",
       "navItems": [
         {
+          "id": "acm",
+          "appId": "openshift",
+          "description": "Manage, govern, and secure multiple Kubernetes clusters across hybrid and multicloud environments.",
+          "title": "Advanced Cluster Management",
+          "isExternal": true,
+          "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec54aa3535cb70ab8c02996"
+        },
+        {
           "title": "Advanced Cluster Security",
           "expandable": true,
           "id": "acs-section",
@@ -268,6 +276,13 @@
           "title": "OpenShift Virtualization",
           "isExternal": true,
           "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f"
+        },
+        {
+          "id": "operators",
+          "appId": "openshift",
+          "description": "Check out the latest recommended operators.",
+          "title": "Operators",
+          "href": "/openshift/overview#recommended-operators"
         }
       ]
     },


### PR DESCRIPTION
## Summary by Sourcery

Add ACM and Operators sections to OpenShift's left navigation across all environments

New Features:
- Add an Advanced Cluster Management (ACM) entry to the OpenShift left navigation
- Add an Operators entry to the OpenShift left navigation

Jira Ticket: [OCMUI-3317](https://issues.redhat.com/browse/OCMUI-3317)