### PR TITLE
Add navigation for the Planning page

### DIFF
--- a/static/stable/prod/navigation/insights-navigation.json
+++ b/static/stable/prod/navigation/insights-navigation.json
@@ -540,6 +540,33 @@
       ]
     },
     {
+      "id": "roadmap",
+      "expandable": true,
+      "title": "Planning",
+      "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
+      "feoReplacement": "planning",
+      "routes": [
+        {
+          "id": "lifecycle",
+          "appId": "roadmap",
+          "title": "Lifecycle",
+          "href": "/insights/planning/lifecycle",
+          "product": "Red Hat Insights",
+          "alt_title": ["lifecycle"],
+          "description": "Support status of operating systems and applications."
+        },
+        {
+          "id": "upcoming",
+          "appId": "roadmap",
+          "title": "Roadmap",
+          "href": "/insights/planning/roadmap",
+          "product": "Red Hat Insights",
+          "alt_title": ["upcoming"],
+          "description": "Upcoming changes in RHEL and applications."
+        }
+      ]
+    },
+    {
       "title": "Business",
       "expandable": true,
       "routes": [


### PR DESCRIPTION
This PR adds the configuration needed to view the Planning page in Insight production

## Summary by Sourcery

New Features:
- Add Planning page entry to the static production Insights navigation JSON