### PR TITLE
Mark stage nav items to use FEO

### DIFF
--- a/static/stable/stage/navigation/subscriptions-navigation.json
+++ b/static/stable/stage/navigation/subscriptions-navigation.json
@@ -16,7 +16,8 @@
       "title": "Subscriptions Inventory",
       "description": "View your purchased subscriptions and explore more information about each one.",
       "href": "/subscriptions/inventory",
-      "icon": "SubscriptionsIcon"
+      "icon": "SubscriptionsIcon",
+      "feoReplacement": "subscription-inventory"
     },
     {
       "id": "subscriptionsUsage",


### PR DESCRIPTION
This marks Subscription Inventory to use the nav items defined in its feo config in stage

## Summary by Sourcery

Enhancements:
- Switch stage subscriptions navigation JSON to reference FEO-configured nav items.