### PR TITLE
remove remediation featureflag and update prod title

### DIFF
--- a/static/stable/prod/navigation/insights-navigation.json
+++ b/static/stable/prod/navigation/insights-navigation.json
@@ -610,7 +610,7 @@
         {
           "id": "remediations",
           "appId": "remediations",
-          "title": "Remediations",
+          "title": "Remediation plans",
           "href": "/insights/remediations",
           "icon": "InsightsIcon",
           "product": "Red Hat Insights",
@@ -627,7 +627,8 @@
             "insights",
             "automation",
             "Ansible",
-            "patch"
+            "patch",
+            "Remediation plans"
           ]
         },
         {

--- a/static/stable/stage/navigation/insights-navigation.json
+++ b/static/stable/stage/navigation/insights-navigation.json
@@ -561,12 +561,6 @@
           "product": "Red Hat Insights",
           "subtitle": "Red Hat Insights for RHEL",
           "description": "Use Ansible Playbooks to resolve configuration, security, and compliance issues identified on your Red Hat Enterprise Linux systems.",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["remediationsV2", false]
-            }
-          ],
           "alt_title": [
             "Remediate",
             "playbook",
@@ -578,36 +572,8 @@
             "insights",
             "automation",
             "Ansible",
-            "patch"
-          ]
-        },
-        {
-          "id": "remediations-v2",
-          "appId": "remediations",
-          "title": "Remediation plans",
-          "href": "/insights/remediations",
-          "icon": "InsightsIcon",
-          "product": "Red Hat Insights",
-          "subtitle": "Red Hat Insights for RHEL",
-          "description": "Use Ansible Playbooks to resolve configuration, security, and compliance issues identified on your Red Hat Enterprise Linux systems.",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["remediationsV2", true]
-            }
-          ],
-          "alt_title": [
-            "Remediate",
-            "playbook",
-            "fix",
-            "solve",
-            "find it fix it",
-            "fifi",
-            "cloud connector",
-            "insights",
-            "automation",
-            "Ansible",
-            "patch"
+            "patch",
+            "Remediation plans"
           ]
         },
         {


### PR DESCRIPTION
This removes an unnecessarily added feature flag for stage environment, and reverts the id to its original. As well as update the title for production