### PR TITLE
Removing HAC intercom config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,6 @@ type IntercomConfig struct {
 	ansible_dev             string
 	openshift               string
 	openshift_dev           string
-	hacCore                 string
 	ansibleDashboard        string
 	ansibleDashboard_dev    string
 	automationHub           string
@@ -253,7 +252,6 @@ func init() {
 		automationAnalytics_dev: os.Getenv("INTERCOM_ANSIBLE_DEV"),
 		openshift:               os.Getenv("INTERCOM_OPENSHIFT"),
 		openshift_dev:           os.Getenv("INTERCOM_OPENSHIFT_DEV"),
-		hacCore:                 os.Getenv("INTERCOM_HAC_CORE"),
 		dbaas:                   os.Getenv("INTERCOM_DBAAS"),
 		dbaas_dev:               os.Getenv("INTERCOM_DBAAS_DEV"),
 		activationKeys:          os.Getenv("INTERCOM_INSIGHTS"),

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -126,11 +126,6 @@ objects:
               secretKeyRef:
                 name: chrome-service-backend
                 key: INTERCOM_ANSIBLE_DEV
-          - name: INTERCOM_HAC_CORE
-            valueFrom:
-              secretKeyRef:
-                name: chrome-service-backend
-                key: INTERCOM_HAC_CORE
           - name: INTERCOM_OPENSHIFT
             valueFrom:
               secretKeyRef:
@@ -197,7 +192,6 @@ objects:
       INTERCOM_ANSIBLE: dGVzdFZhbHVl
       INTERCOM_ANSIBLE_DEV: dGVzdFZhbHVl
       INTERCOM_DEFAULT: dGVzdFZhbHVl
-      INTERCOM_HAC_CORE: dGVzdFZhbHVl
       INTERCOM_OPENSHIFT_DEV: dGVzdFZhbHVl
       SEARCH_CLIENT_SECRET_PROD: dGVzdFZhbHVl
       SEARCH_CLIENT_SECRET_STAGE: dGVzdFZhbHVl

--- a/rest/service/identity.go
+++ b/rest/service/identity.go
@@ -27,7 +27,6 @@ type IntercomPayload struct {
 
 const (
 	OpenShift           IntercomApp = "openshift"
-	HacCore             IntercomApp = "hacCore"
 	Acs                 IntercomApp = "acs"
 	Ansible             IntercomApp = "ansible"
 	AnsibleDashboard    IntercomApp = "ansibleDashboard"
@@ -63,11 +62,11 @@ func debugFavoritesIdentity(userId string) {
 
 func (ib IntercomApp) IsValidApp() error {
 	switch ib {
-	case OpenShift, HacCore, Ansible, Acs, AnsibleDashboard, AutomationHub, AutomationAnalytics, DBAAS, ActivationKeys, Advisor, Compliance, Connector, ContentSources, Dashboard, ImageBuilder, Inventory, Malware, Patch, Policies, Registration, Remediations, Ros, Tasks, Vulnerability:
+	case OpenShift, Ansible, Acs, AnsibleDashboard, AutomationHub, AutomationAnalytics, DBAAS, ActivationKeys, Advisor, Compliance, Connector, ContentSources, Dashboard, ImageBuilder, Inventory, Malware, Patch, Policies, Registration, Remediations, Ros, Tasks, Vulnerability:
 		return nil
 	}
 
-	return fmt.Errorf("invalid bundle string. Expected one of %s, %s, got %s", OpenShift, HacCore, ib)
+	return fmt.Errorf("invalid bundle string. Expected one of %s, %s, got %s", OpenShift, ib)
 }
 
 func parseUserBundles(user models.UserIdentity) (map[string]bool, error) {

--- a/rest/service/identity.go
+++ b/rest/service/identity.go
@@ -66,7 +66,7 @@ func (ib IntercomApp) IsValidApp() error {
 		return nil
 	}
 
-	return fmt.Errorf("invalid bundle string. Expected one of %s, %s, got %s", OpenShift, ib)
+	return fmt.Errorf("invalid intercom bundle string. Expected one like %s, got %s", OpenShift, ib)
 }
 
 func parseUserBundles(user models.UserIdentity) (map[string]bool, error) {


### PR DESCRIPTION
## Summary by Sourcery

Remove HAC Core intercom configuration by eliminating environment variables, constants, and validation logic associated with the deprecated app.

Enhancements:
- Drop INTERCOM_HAC_CORE secret and env var from container deployment manifest
- Remove HacCore constant and associated validation in the Intercom identity service
- Eliminate hacCore field and environment binding from application configuration

Deployment:
- Remove HAC Core intercom secret from clowdapp deployment YAML