### PR TITLE
fix: use partial index on the user_identities table account id field

### DIFF
--- a/rest/models/UserIdentity.go
+++ b/rest/models/UserIdentity.go
@@ -28,7 +28,7 @@ type LastVisitedRequest struct {
 
 type UserIdentity struct {
 	BaseModel
-	AccountId              string                            `json:"accountId,omitempty" gorm:"index:idx_active_user,where:deleted_at IS NULL"`
+	AccountId              string                            `json:"accountId,omitempty"`
 	FirstLogin             bool                              `json:"firstLogin"`
 	DayOne                 bool                              `json:"dayOne"`
 	LastLogin              time.Time                         `json:"lastLogin"`

--- a/rest/models/UserIdentity.go
+++ b/rest/models/UserIdentity.go
@@ -28,7 +28,7 @@ type LastVisitedRequest struct {
 
 type UserIdentity struct {
 	BaseModel
-	AccountId              string                            `json:"accountId,omitempty"`
+	AccountId              string                            `json:"accountId,omitempty" gorm:"index,where:deleted_at IS NULL"`
 	FirstLogin             bool                              `json:"firstLogin"`
 	DayOne                 bool                              `json:"dayOne"`
 	LastLogin              time.Time                         `json:"lastLogin"`

--- a/rest/models/UserIdentity.go
+++ b/rest/models/UserIdentity.go
@@ -28,7 +28,7 @@ type LastVisitedRequest struct {
 
 type UserIdentity struct {
 	BaseModel
-	AccountId              string                            `json:"accountId,omitempty" gorm:"index,where:deleted_at IS NULL"`
+	AccountId              string                            `json:"accountId,omitempty" gorm:"index:idx_active_user,where:deleted_at IS NULL"`
 	FirstLogin             bool                              `json:"firstLogin"`
 	DayOne                 bool                              `json:"dayOne"`
 	LastLogin              time.Time                         `json:"lastLogin"`


### PR DESCRIPTION
Follow up from our investigations into slow DB queries.

This will add a partial index on the account_id in the user_identities table (where deleted_at is null).

~We use gorm autoMigrate functionality - so this annotation should be picked up and applied to the database when the migrate script is run (on pod init): https://github.com/RedHatInsights/chrome-service-backend/blob/main/cmd/migrate/migrate.go#L102~

~Setting as draft so I can test a few things locally first.~

Edit: if we want to use `concurrently` this cannot be done within an existing transaction/automigrate - so I've shifted to creating the index through executing SQL in the migrate script (after the automigrate completes). This can also be done in app-interface, but I wanted to stick to using our migrate script.

## Summary by Sourcery

Enhancements:
- Add GORM partial index on the user_identities table’s account_id field to only index non-deleted records