### PR TITLE
chore(deps): upgrade version of go from 1.23.6 to 1.23.9 for patches

### DIFF
--- a/.tekton/chrome-service-pull-request.yaml
+++ b/.tekton/chrome-service-pull-request.yaml
@@ -281,7 +281,7 @@ spec:
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           name: use-trusted-artifact
         - computeResources: {}
-          image: registry.access.redhat.com/ubi8/go-toolset:1.23.6-1
+          image: registry.access.redhat.com/ubi8/go-toolset:1.23.9-2
           name: validate-schemas-files
           script: "#!/bin/bash\nset -ex\nmake validate-schema\nmake publish-search-index-dry-run\n make parse-services\nmake generate-search-index  \n"
           securityContext:
@@ -375,7 +375,7 @@ spec:
             value: $(params.UNLEASH_API_TOKEN)
           - name: UNLEASH_ADMIN_TOKEN
             value: $(params.UNLEASH_ADMIN_TOKEN)
-          image: registry.access.redhat.com/ubi8/go-toolset:1.23.6-1
+          image: registry.access.redhat.com/ubi8/go-toolset:1.23.9-2
           name: unit-tests
           script: |
             #!/bin/bash

--- a/.tekton/chrome-service-push.yaml
+++ b/.tekton/chrome-service-push.yaml
@@ -540,7 +540,7 @@ spec:
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           name: use-trusted-artifact
         - computeResources: {}
-          image: registry.access.redhat.com/ubi8/go-toolset:1.23.6-1
+          image: registry.access.redhat.com/ubi8/go-toolset:1.23.9-2
           name: validate-schemas-files
           script: "#!/bin/bash\nset -ex\nmake validate-schema\nmake publish-search-index-dry-run\n make parse-services\nmake generate-search-index  \n"
           securityContext:
@@ -634,7 +634,7 @@ spec:
             value: $(params.UNLEASH_API_TOKEN)
           - name: UNLEASH_ADMIN_TOKEN
             value: $(params.UNLEASH_ADMIN_TOKEN)
-          image: registry.access.redhat.com/ubi8/go-toolset:1.23.6-1
+          image: registry.access.redhat.com/ubi8/go-toolset:1.23.9-2
           name: unit-tests
           script: |
             #!/bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1744294473 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 AS builder
 WORKDIR $GOPATH/src/chrome-service-backend/
 # TODO: Use --exclude when stable docker version available
 COPY api api

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/chrome-service-backend
 
-go 1.23.6
+go 1.23.9
 
 require (
 	github.com/Unleash/unleash-client-go/v3 v3.7.4


### PR DESCRIPTION
Updates chrome service backend to latest minor version of Go for patches and fixes.

## Summary by Sourcery

Build:
- Bump Go version to 1.23.9 in go.mod

## Summary by Sourcery

Build:
- Bump Go version to 1.23.9 in Dockerfile and go.mod