### PR TITLE
Remove references to Red Hat Marketplace

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -684,13 +684,6 @@
         "links": [
           {
             "isExternal": true,
-            "href": "https://marketplace.redhat.com/en-us",
-            "title": "Red Hat Marketplace",
-            "icon": "RHIcon",
-            "description": "Find, try, purchase, and deploy your software across clouds."
-          },
-          {
-            "isExternal": true,
             "href": "https://www.redhat.com/en/products/trials",
             "title": "Red Hat Product Trials",
             "icon": "RHIcon",

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -684,13 +684,6 @@
         "links": [
           {
             "isExternal": true,
-            "href": "https://marketplace.redhat.com/en-us",
-            "title": "Red Hat Marketplace",
-            "icon": "RHIcon",
-            "description": "Find, try, purchase, and deploy your software across clouds."
-          },
-          {
-            "isExternal": true,
             "href": "https://www.redhat.com/en/products/trials",
             "title": "Red Hat Product Trials",
             "icon": "RHIcon",

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -710,13 +710,6 @@
         "links": [
           {
             "isExternal": true,
-            "href": "https://marketplace.redhat.com/en-us",
-            "title": "Red Hat Marketplace",
-            "icon": "RHIcon",
-            "description": "Find, try, purchase, and deploy your software across clouds."
-          },
-          {
-            "isExternal": true,
             "href": "https://www.redhat.com/en/products/trials",
             "title": "Red Hat Product Trials",
             "icon": "RHIcon",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -722,13 +722,6 @@
         "links": [
           {
             "isExternal": true,
-            "href": "https://marketplace.redhat.com/en-us",
-            "title": "Red Hat Marketplace",
-            "icon": "RHIcon",
-            "description": "Find, try, purchase, and deploy your software across clouds."
-          },
-          {
-            "isExternal": true,
             "href": "https://www.redhat.com/en/products/trials",
             "title": "Red Hat Product Trials",
             "icon": "RHIcon",


### PR DESCRIPTION
All services dropdown - Remove references to Red Hat Marketplace

- Try and Buy section

https://issues.redhat.com/browse/RHCLOUD-40930

## Summary by Sourcery

Chores:
- Remove 'Try and Buy' entries for Red Hat Marketplace from static service JSON files across beta and stable, stage and prod environments