### PR TITLE
updating sc tekton files to shared pipeline

### DIFF
--- a/.tekton/chrome-service-sc-pull-request.yaml
+++ b/.tekton/chrome-service-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.24.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: chrome-service-sc

--- a/.tekton/chrome-service-sc-push.yaml
+++ b/.tekton/chrome-service-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.24.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: chrome-service-sc


### PR DESCRIPTION
Also testing pipelines

## Summary by Sourcery

Consolidate Tekton pipeline configs for chrome-service by referencing a shared docker-build pipeline instead of duplicate inline specs and clean up related annotations.

Enhancements:
- Remove inline pipelineSpec definitions from pull-request and push Tekton YAML files
- Add pipelineRef to reference the shared docker-build pipeline
- Remove pipelinesascode cancel-in-progress annotations