### PR TITLE
adding sc tekton files to main

### DIFF
--- a/.tekton/chrome-service-sc-pull-request.yaml
+++ b/.tekton/chrome-service-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.24.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/blob/main/pipelines/docker-build-run-unit-tests-dynamic-env.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: chrome-service-sc
@@ -31,6 +31,45 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: PGSQL_USER
+    value: chrome
+  - name: PGSQL_PASSWORD
+    value: chrome
+  - name: PGSQL_HOSTNAME
+    value: localhost
+  - name: PGSQL_PORT
+    value: '5432'
+  - name: PGSQL_DATABASE
+    value: db
+  - name: UNLEASH_API_TOKEN
+    value: default:development.unleash-insecure-api-token
+  - name: UNLEASH_ADMIN_TOKEN
+    value: '*:*.unleash-insecure-api-token'
+  # Environment variables specific to unit tests
+  - name: env-vars
+    value: |
+      PGSQL_USER=chrome
+      PGSQL_PASSWORD=chrome
+      PGSQL_HOSTNAME=localhost
+      PGSQL_PORT=5432
+      PGSQL_DATABASE=db
+      UNLEASH_API_TOKEN=default:development.unleash-insecure-api-token
+      UNLEASH_ADMIN_TOKEN=*:*.unleash-insecure-api-token
+  - name: unit-tests-script
+    value: |
+      #!/bin/bash
+      set -ex
+      
+      export PGSQL_USER="$(params.PGSQL_USER)"
+      export PGSQL_PASSWORD="$(params.PGSQL_PASSWORD)"
+      export PGSQL_HOSTNAME="$(params.PGSQL_HOSTNAME)"
+      export PGSQL_PORT="$(params.PGSQL_PORT)"
+      export PGSQL_DATABASE="$(params.PGSQL_DATABASE)"
+      export UNLEASH_API_TOKEN="$(params.UNLEASH_API_TOKEN)"
+      export UNLEASH_ADMIN_TOKEN="$(params.UNLEASH_ADMIN_TOKEN)"
+
+      make migrate
+      make test
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/.tekton/chrome-service-sc-push.yaml
+++ b/.tekton/chrome-service-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.24.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/blob/main/pipelines/docker-build-run-unit-tests-dynamic-env.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: chrome-service-sc
@@ -28,6 +28,45 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: PGSQL_USER
+    value: chrome
+  - name: PGSQL_PASSWORD
+    value: chrome
+  - name: PGSQL_HOSTNAME
+    value: localhost
+  - name: PGSQL_PORT
+    value: '5432'
+  - name: PGSQL_DATABASE
+    value: db
+  - name: UNLEASH_API_TOKEN
+    value: default:development.unleash-insecure-api-token
+  - name: UNLEASH_ADMIN_TOKEN
+    value: '*:*.unleash-insecure-api-token'
+  # Environment variables specific to unit tests
+  - name: env-vars
+    value: |
+      PGSQL_USER=chrome
+      PGSQL_PASSWORD=chrome
+      PGSQL_HOSTNAME=localhost
+      PGSQL_PORT=5432
+      PGSQL_DATABASE=db
+      UNLEASH_API_TOKEN=default:development.unleash-insecure-api-token
+      UNLEASH_ADMIN_TOKEN=*:*.unleash-insecure-api-token
+  - name: unit-tests-script
+    value: |
+      #!/bin/bash
+      set -ex
+
+      export PGSQL_USER="$(params.PGSQL_USER)"
+      export PGSQL_PASSWORD="$(params.PGSQL_PASSWORD)"
+      export PGSQL_HOSTNAME="$(params.PGSQL_HOSTNAME)"
+      export PGSQL_PORT="$(params.PGSQL_PORT)"
+      export PGSQL_DATABASE="$(params.PGSQL_DATABASE)"
+      export UNLEASH_API_TOKEN="$(params.UNLEASH_API_TOKEN)"
+      export UNLEASH_ADMIN_TOKEN="$(params.UNLEASH_ADMIN_TOKEN)"
+      
+      make migrate
+      make test
   pipelineRef:
     name: docker-build
   taskRunTemplate:


### PR DESCRIPTION
Adding sc tekton files to main

## Summary by Sourcery

Add Tekton pipeline run configurations for Chrome Service SC to automate docker builds on pull request and push events for the security-compliance branch

CI:
- Add Tekton PipelineRun for pull_request events targeting the security-compliance branch
- Add Tekton PipelineRun for push events targeting the security-compliance branch