### PR TITLE
Added Cost Management feoReplacements for OpenShift nav items in stage

### DIFF
--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -107,6 +107,7 @@
           "expandable": true,
           "description": "Understand and track costs for your OpenShift clusters and workloads.",
           "id": "costManagement",
+          "feoReplacement": "cost-management.nav",
           "routes": [
             {
               "id": "costManagementOverview",

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -121,6 +121,7 @@
           "expandable": true,
           "description": "Understand and track costs for your OpenShift clusters and workloads.",
           "id": "costManagement",
+          "feoReplacement": "cost-management.nav",
           "routes": [
             {
               "id": "costManagementOverview",


### PR DESCRIPTION
Added `feoReplacements` for OpenShift nav items in stage

See https://github.com/project-koku/koku-ui/blob/main/deploy/frontend.yaml

## Summary by Sourcery

Add Cost Management feoReplacements to OpenShift navigation configuration for the stage environment

Enhancements:
- Insert feoReplacements entries for Cost Management nav items in the stable stage OpenShift config
- Insert feoReplacements entries for Cost Management nav items in the beta stage OpenShift config