### PR TITLE
Added Cost Management feoReplacements for staging nav items in stage

### DIFF
--- a/static/beta/stage/navigation/staging-navigation.json
+++ b/static/beta/stage/navigation/staging-navigation.json
@@ -38,6 +38,7 @@
             "filterable": false,
             "id": "costManagementMfe",
             "description": "Cost Management Microfrontend with Module Federation",
+            "feoReplacement": "cost-management-mfe.nav",
             "routes": [
                 {
                     "title": "ROS",

--- a/static/stable/stage/navigation/staging-navigation.json
+++ b/static/stable/stage/navigation/staging-navigation.json
@@ -40,6 +40,7 @@
             "filterable": false,
             "id": "costManagementMfe",
             "description": "Cost Management Microfrontend with Module Federation",
+            "feoReplacement": "cost-management-mfe.nav",
             "routes": [
                 {
                     "title": "ROS",


### PR DESCRIPTION
Added `feoReplacements` for staging nav items in stage

See https://github.com/project-koku/koku-ui-mfe/blob/main/deploy/frontend.yaml

## Summary by Sourcery

Enhancements:
- Add feoReplacements mapping for Cost Management nav items in both beta and stable stage navigation JSON files