### PR TITLE
Update feo-migration-guide.md

### DIFF
--- a/docs/feo-migration-guide.md
+++ b/docs/feo-migration-guide.md
@@ -730,6 +730,6 @@ The function will throw an error if the validation fails.
 **Q: Why can I not preview my changes to the frontend.yaml CRD locally?**
 
 A: This can be for numerous reasons, but by far the most common reason for this issue during an apps initial migration is:
-1. You must deploy the initial `feoConfigEnabled: true`, nav, service tile, module, search, etc. changes in the frontend CRD to the envrionment you are proxying your local env to. This is only necessary for the initial config migration
+1. You must deploy the initial `feoConfigEnabled: true`, nav, service tile, module, search, etc. changes in the frontend CRD to the environment you are proxying your local env to. This is only necessary for the initial config migration
 2. You should be using the latest versions of our fec packages
 3. Check the console logs for any related CRD validation errors

--- a/docs/feo-migration-guide.md
+++ b/docs/feo-migration-guide.md
@@ -30,7 +30,7 @@ module.exports = {
 
 To have full development support for the latest FEO features, update the build and development dependencies in your project. The tools are validating the CRD during development/build time.
 
-Make sure to upgrade `@redhat-cloud-services/frontend-components-config@^6.5.0` and `@redhat-cloud-services/frontend-components-config-utilities@^4.2.0` dependencies. Do not pin the versions. Use the `^` version range to ensure you have the latest version when upgrading. These should be listed in your project `package.json`. Your project may have one, or both dependencies listed. A package is installed if:
+Make sure to upgrade `@redhat-cloud-services/frontend-components-config@^6.6.9` and `@redhat-cloud-services/frontend-components-config-utilities@^4.6.0` dependencies. Do not pin the versions. Use the `^` version range to ensure you have the latest version when upgrading. These should be listed in your project `package.json`. Your project may have one, or both dependencies listed. A package is installed if:
   - `@redhat-cloud-services/frontend-components-config` if you are using the FEC binary for your build and development, or if you are creating your webpack config using the presets from the package.
   - `@redhat-cloud-services/frontend-components-config-utilities` if you are using the webpack development proxy directly and not via the config package.
 
@@ -724,3 +724,12 @@ try {
 ```
 
 The function will throw an error if the validation fails.
+
+## Frequently Asked Questions
+
+**Q: Why can I not preview my changes to the frontend.yaml CRD locally?**
+
+A: This can be for numerous reasons, but by far the most common reason for this issue during an apps initial migration is:
+1. You must deploy the initial `feoConfigEnabled: true`, nav, service tile, module, search, etc. changes in the frontend CRD to the envrionment you are proxying your local env to. This is only necessary for the initial config migration
+2. You should be using the latest versions of our fec packages
+3. Check the console logs for any related CRD validation errors


### PR DESCRIPTION
Add brief section for FAQ's during migration

## Summary by Sourcery

Update the FEO migration guide with updated dependency versions and a new FAQ section addressing local CRD preview issues.

Documentation:
- bump versions of @redhat-cloud-services/frontend-components-config to ^6.6.9 and frontend-components-config-utilities to ^4.6.0
- add a Frequently Asked Questions section explaining common CRD preview errors during initial migration