### PR TITLE
fix(RHINENG-17212): Add missing Compliance ids

### DIFF
--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -454,6 +454,7 @@
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
           {
+            "id": "compliance",
             "href": "/insights/compliance/reports",
             "icon": "InsightsIcon",
             "title": "Compliance",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -466,6 +466,7 @@
             "description": "Identify and prioritize security vulnerabilities within your Red Hat Enterprise Linux systems based on severity and frequency."
           },
           {
+            "id": "compliance",
             "href": "/insights/compliance/reports",
             "icon": "InsightsIcon",
             "title": "Compliance",


### PR DESCRIPTION
This PR adds missing ids to compliance for service tiles according to the [Frontend operator migration doc](https://github.com/RedHatInsights/chrome-service-backend/blob/main/docs/feo-migration-guide.md#services-dropdown-replacement)