### PR TITLE
fix(learning-resources): remove learning resources navigation from itless env

### DIFF
--- a/static/beta/itless/modules/fed-modules.json
+++ b/static/beta/itless/modules/fed-modules.json
@@ -310,24 +310,6 @@
                         }
                     },
                     {
-                        "pathname": "/settings/learning-resources",
-                        "props": {
-                            "bundle": "settings"
-                        }
-                    },
-                    {
-                        "pathname": "/iam/learning-resources",
-                        "props": {
-                            "bundle": "iam"
-                        }
-                    },
-                    {
-                        "pathname": "/subscriptions/learning-resources",
-                        "props": {
-                            "bundle": "subscriptions"
-                        }
-                    },
-                    {
                         "pathname": "/application-services/learning-resources",
                         "props": {
                             "bundle": "application-services"

--- a/static/beta/itless/navigation/iam-navigation.json
+++ b/static/beta/itless/navigation/iam-navigation.json
@@ -56,12 +56,6 @@
           "product": "Identity & Access Management"
         }
       ]
-    },
-    {
-      "id": "learningResources",
-      "appId": "learningResources",
-      "title": "Learning Resources",
-      "href": "/iam/learning-resources"
     }
   ],
   "alt_title": [

--- a/static/beta/itless/navigation/settings-navigation.json
+++ b/static/beta/itless/navigation/settings-navigation.json
@@ -50,12 +50,6 @@
                   "href": "/settings/notifications/user-preferences"
               }
           ]
-        },
-        {
-          "id": "learningResources",
-          "appId": "learningResources",
-          "title": "Learning Resources",
-          "href": "/settings/learning-resources"
-      }
+        }
     ]
 }

--- a/static/stable/itless/modules/fed-modules.json
+++ b/static/stable/itless/modules/fed-modules.json
@@ -313,24 +313,6 @@
                         }
                     },
                     {
-                        "pathname": "/settings/learning-resources",
-                        "props": {
-                            "bundle": "settings"
-                        }
-                    },
-                    {
-                        "pathname": "/iam/learning-resources",
-                        "props": {
-                            "bundle": "iam"
-                        }
-                    },
-                    {
-                        "pathname": "/subscriptions/learning-resources",
-                        "props": {
-                            "bundle": "subscriptions"
-                        }
-                    },
-                    {
                         "pathname": "/application-services/learning-resources",
                         "props": {
                             "bundle": "application-services"

--- a/static/stable/itless/navigation/iam-navigation.json
+++ b/static/stable/itless/navigation/iam-navigation.json
@@ -56,13 +56,6 @@
           "product": "Identity & Access Management"
         }
       ]
-    },
-    {
-      "id": "learningResources",
-      "appId": "learningResources",
-      "title": "Learning Resources",
-      "href": "/iam/learning-resources",
-      "feoReplacement": "learningResourcesIAM"
     }
   ],
   "alt_title": [

--- a/static/stable/itless/navigation/settings-navigation.json
+++ b/static/stable/itless/navigation/settings-navigation.json
@@ -50,13 +50,6 @@
                   "href": "/settings/notifications/user-preferences"
               }
           ]
-        },
-        {
-          "id": "learningResources",
-          "appId": "learningResources",
-          "title": "Learning Resources",
-          "href": "/settings/learning-resources",
-          "feoReplacement": "learningResourcesSettings"
         }
     ]
 }


### PR DESCRIPTION
We need to remove learning resources (iam/learning-resources and settings/learning-resources) navigation from itless environment 

for [HCMSEC-1226](https://issues.redhat.com/browse/HCMSEC-1226)