### PR TITLE
Change assisted installer app route to /openshift/assisted-installer

### DIFF
--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -887,7 +887,11 @@
                 "module": "./RootApp",
                 "routes": [
                     {
-                        "pathname": "/openshift/assisted-installer-app"
+                        "permissions": [{
+                            "method": "featureFlag",
+                            "args": ["openshift.assisted-installer.route", true]
+                        }],
+                        "pathname": "/openshift/assisted-installer"
                     }
                 ]
             }

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -852,7 +852,11 @@
         "module": "./RootApp",
         "routes": [
           {
-            "pathname": "/openshift/assisted-installer-app"
+            "permissions": [{
+                "method": "featureFlag",
+                "args": ["openshift.assisted-installer.route", true]
+            }],
+            "pathname": "/openshift/assisted-installer"
           }
         ]
       }


### PR DESCRIPTION
## Summary by Sourcery

Update the assisted installer application route to use /openshift/assisted-installer in both production and staging fed-modules.json configurations.

Enhancements:
- Change the assisted installer app path to /openshift/assisted-installer in static/stable/prod/modules/fed-modules.json
- Change the assisted installer app path to /openshift/assisted-installer in static/stable/stage/modules/fed-modules.json