### PR TITLE
Remove Directory & Domain Services (idmsvc) service

### DIFF
--- a/static/beta/stage/main.yml
+++ b/static/beta/stage/main.yml
@@ -87,13 +87,6 @@ export:
     versions:
       - v1
 
-idmsvc:
-  title: "Directory and Domain Services"
-  api:
-    versions:
-      - v1
-    isBeta: true
-
 image-builder:
   title: Image Builder
   api:

--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -1026,21 +1026,6 @@
             }
         ]
     },
-    "idmsvc": {
-        "manifestLocation": "/apps/idmsvc/fed-mods.json",
-        "defaultDocumentTitle": "Directory and Domain Services",
-        "modules": [
-            {
-                "id": "idmsvc",
-                "module": "./RootApp",
-                "routes": [
-                    {
-                        "pathname": "/settings/idmsvc"
-                    }
-                ]
-            }
-        ]
-    },
     "ansibleWisdomAdminDashboard": {
         "manifestLocation": "/apps/ansible-wisdom-admin-dashboard/fed-mods.json",
         "config": {

--- a/static/beta/stage/navigation/settings-navigation.json
+++ b/static/beta/stage/navigation/settings-navigation.json
@@ -41,14 +41,6 @@
             "href": "/settings/learning-resources"
         },
         {
-            "id": "idmsvc",
-            "appId": "idmsvc",
-            "title": "Directory and Domain Services",
-            "description": "Directory and Domain Services for console.redhat.com",
-            "href": "/settings/idmsvc",
-            "icon": "PlaceholderIcon"
-        },
-        {
             "title": "Notifications",
             "id": "notifications",
             "description": "A standardized way of notifying users of events for supported services on the Hybrid Cloud Console.",

--- a/static/stable/prod/main.yml
+++ b/static/stable/prod/main.yml
@@ -104,12 +104,6 @@ content-sources:
     versions:
       - v1
 
-idmsvc:
-  title: Directory and Domain services
-  api:
-    versions:
-      - v1
-
 cost-management:
   title: Cost Management
   api:

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -979,21 +979,6 @@
             }
         ]
     },
-    "idmsvc": {
-        "manifestLocation": "/apps/idmsvc/fed-mods.json",
-        "defaultDocumentTitle": "Directory and Domain Services",
-        "modules": [
-            {
-                "id": "idmsvc",
-                "module": "./RootApp",
-                "routes": [
-                    {
-                        "pathname": "/settings/idmsvc"
-                    }
-                ]
-            }
-        ]
-    },
     "learningResources": {
         "manifestLocation": "/apps/learning-resources/fed-mods.json",
         "modules": [

--- a/static/stable/prod/navigation/settings-navigation.json
+++ b/static/stable/prod/navigation/settings-navigation.json
@@ -97,35 +97,6 @@
         "title": "Learning Resources",
         "href": "/settings/learning-resources",
         "feoReplacement": "learningResourcesSettings"
-      },
-      {
-          "id": "idmsvc",
-          "appId": "idmsvc",
-          "title": "Directory and Domain Services",
-          "description": "Register identity and access systems to enable machines to automatically join a domain",
-          "href": "/settings/idmsvc",
-          "icon": "PlaceholderIcon",
-          "permissions": [
-            {
-              "method": "isBeta"
-            }
-          ],
-          "alt_title": [
-              "directory",
-              "domain",
-              "ipa",
-              "freeipa",
-              "idm",
-              "sssd",
-              "ldap",
-              "kerberos",
-              "join",
-              "enrol",
-              "enroll",
-              "authentication",
-              "authorisation",
-              "authorization"
-            ]
-        }
+      }
   ]
 }

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -161,30 +161,6 @@
           "iam.serviceAccounts",
           "iam.idpIntegration"
         ]
-      },
-      {
-        "id": "host-inventory",
-        "isGroup": true,
-        "title": "Host Identity",
-        "links": [
-          "settings.idmsvc"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "integrations-notifications",
-    "icon": "BellIcon",
-    "title": "Integrations and Notifications",
-    "description": "Alerts users to events, using email and integrations such as webhooks.",
-    "links": [
-      {
-        "id": "settings",
-        "isGroup": true,
-        "title": "Console Settings",
-        "links": [
-          "settings.idmsvc"
-        ]
       }
     ]
   },
@@ -487,8 +463,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify potential malware on your Red Hat Enterprise Linux systems."
           },
-          "insights.remediations",
-          "settings.idmsvc"
+          "insights.remediations"
         ]
       },
       {

--- a/static/stable/stage/main.yml
+++ b/static/stable/stage/main.yml
@@ -75,13 +75,6 @@ export:
     versions:
       - v1
 
-idmsvc:
-  title: "Directory and Domain Services"
-  api:
-    versions:
-      - v1
-    isBeta: true
-
 image-builder:
   title: Image Builder
   api:

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -1055,21 +1055,6 @@
           }
       ]
   },
-    "idmsvc": {
-        "manifestLocation": "/apps/idmsvc/fed-mods.json",
-        "defaultDocumentTitle": "Directory and Domain Services",
-        "modules": [
-            {
-                "id": "idmsvc",
-                "module": "./RootApp",
-                "routes": [
-                    {
-                        "pathname": "/settings/idmsvc"
-                    }
-                ]
-            }
-        ]
-    },
   "learningResources": {
       "manifestLocation": "/apps/learning-resources/fed-mods.json",
       "modules": [

--- a/static/stable/stage/navigation/settings-navigation.json
+++ b/static/stable/stage/navigation/settings-navigation.json
@@ -98,35 +98,6 @@
           "title": "Learning Resources",
           "href": "/settings/learning-resources",
           "feoReplacement": "learningResourcesSettings"
-        },
-        {
-            "id": "idmsvc",
-            "appId": "idmsvc",
-            "title": "Directory and Domain Services",
-            "description": "Register identity and access systems to enable machines to automatically join a domain",
-            "href": "/settings/idmsvc",
-            "icon": "PlaceholderIcon",
-            "permissions": [
-              {
-                "method": "isBeta"
-              }
-            ],
-            "alt_title": [
-                "directory",
-                "domain",
-                "ipa",
-                "freeipa",
-                "idm",
-                "sssd",
-                "ldap",
-                "kerberos",
-                "join",
-                "enrol",
-                "enroll",
-                "authentication",
-                "authorisation",
-                "authorization"
-            ]
         }
     ]
 }

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -162,30 +162,6 @@
           "iam.serviceAccounts",
           "iam.idpIntegration"
         ]
-      },
-      {
-        "id": "host-inventory",
-        "isGroup": true,
-        "title": "Host Identity",
-        "links": [
-          "settings.idmsvc"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "integrations-notifications",
-    "icon": "BellIcon",
-    "title": "Integrations and Notifications",
-    "description": "Alerts users to events, using email and integrations such as webhooks.",
-    "links": [
-      {
-        "id": "settings",
-        "isGroup": true,
-        "title": "Console Settings",
-        "links": [
-          "settings.idmsvc"
-        ]
       }
     ]
   },
@@ -499,8 +475,7 @@
             "subtitle": "Red Hat Insights for RHEL",
             "description": "Identify potential malware on your Red Hat Enterprise Linux systems."
           },
-          "insights.remediations",
-          "settings.idmsvc"
+          "insights.remediations"
         ]
       },
       {


### PR DESCRIPTION
The Domain Join feature is being decommissioned.  Remove it from the UI.

https://issues.redhat.com/browse/HMS-9035

## Summary by Sourcery

Remove the Directory & Domain Services (idmsvc) service from the static UI configuration to decommission the Domain Join feature

Chores:
- Delete idmsvc entries from main.yml exports in beta and stable (stage and prod)
- Remove idmsvc references from module, navigation, and services JSON files across beta and stable (stage and prod)