### PR TITLE
Update UBI-9 to latest build 1.24.6-1755755147

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1754467841 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1755755147 AS builder
 WORKDIR $GOPATH/src/chrome-service-backend/
 # TODO: Use --exclude when stable docker version available
 COPY api api


### PR DESCRIPTION
Follow up to https://github.com/RedHatInsights/chrome-service-backend/pull/924

Fixes the failing Grype Vulnerability Scan from above PR.  🎉