### PR TITLE
Removed and migrated service-tiles and search entries to uhc-portal

### DIFF
--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -93,18 +93,6 @@
     ]
   },
   {
-    "id": "rosa",
-    "links": [
-      {
-        "custom": true,
-        "id": "ROSA.custom",
-        "href": "/openshift/create/rosa/getstarted",
-        "title": "Red Hat OpenShift Service for AWS",
-        "description": "ROSA allows you to deploy fully operational and managed Red Hat OpenShift clusters while leveraging the full breadth and depth of AWS"
-      }
-    ]
-  },
-  {
     "id": "ansible-advisor",
     "links": [
       {
@@ -136,39 +124,6 @@
     "id": "ACS-custom",
     "links": [
       "openshift.acs-section"
-    ]
-  },
-  {
-    "id": "create-clusters",
-    "links": [
-      {
-      "custom": true,
-      "id": "OPENSHIFT.cluster.create.aws",
-      "href": "/openshift/create",
-      "title": "Red Hat OpenShift Service on AWS",
-      "alt_title": ["ROSA", "AWS", "OpenShift on AWS"]
-      },
-      {
-      "custom": true,
-      "id": "OPENSHIFT.cluster.create.dedicated",
-      "href": "/openshift/create",
-      "title": "Red Hat OpenShift Dedicated",
-      "alt_title": ["OSD","Dedicated", "GCP", "AWS", "OpenShift on AWS", "OpenShift on GCP"]
-      },
-      {
-      "custom": true,
-      "id": "OPENSHIFT.cluster.create.azure",
-      "href": "/openshift/create",
-      "title": "Azure Red Hat OpenShift",
-      "alt_title": ["ARO", "Azure", "OpenShift on Azure"]
-      },
-      {
-      "custom": true,
-      "id": "OPENSHIFT.cluster.create.ibm",
-      "href": "/openshift/create",
-      "title": "Red Hat OpenShift on IBM Cloud",
-      "alt_title": ["ROKS", "IBM Cloud", "OpenShift on IBM Cloud"]
-      }
     ]
   },
   {
@@ -390,13 +345,6 @@
           "errata",
           "Errata"
         ]
-      },
-      {
-        "custom": true,
-        "id": "OPENSHIFT.clusterManager",
-        "title": "Cluster Manager",
-        "href": "/openshift",
-        "description": "View, Register, or Create an OpenShift Cluster."
       },
       {
         "custom": true,

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -71,25 +71,6 @@
     "description": "Run your applications in a consistent and isolated environment.",
     "links": [
       {
-        "isGroup": true,
-        "id": "openshift",
-        "title": "OpenShift",
-        "links": [
-          {
-            "title": "Overview",
-            "href": "/openshift/overview",
-            "icon": "OpenShiftIcon",
-            "description": "Browse options for various OpenShift cluster types to find what fits your needs."
-          },
-          {
-            "title": "Clusters",
-            "href": "/openshift",
-            "icon": "OpenShiftIcon",
-            "description": "View, Register, or Create an OpenShift Cluster."
-          }
-        ]
-      },
-      {
         "id": "quay",
         "isGroup": true,
         "title": "Quay.io",
@@ -179,14 +160,6 @@
           "insights.imageBuilder",
           "insights.inventory",
           "insights.workspaces"
-        ]
-      },
-      {
-        "id": "openshift",
-        "isGroup": true,
-        "title": "OpenShift",
-        "links": [
-          "openshift.clusters"
         ]
       },
       {
@@ -348,51 +321,7 @@
   {
     "id": "operators",
     "title": "Operators",
-    "links": [
-      {
-        "isGroup": true,
-        "id": "openshift",
-        "title": "OpenShift",
-        "links": [
-          {
-            "isExternal": true,
-            "href": "https://catalog.redhat.com/software/container-stacks/detail/63b85b573112fe5a95ee9a3a",
-            "title": "OpenShift AI",
-            "description": "Create, train, and serve AI/ML models with OpenShift."
-          },
-          {
-            "isExternal": true,
-            "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53f218b6f188e53644c4f",
-            "title": "OpenShift Virtualization",
-            "description": "Run and manage virtual machines on OpenShift."
-          },
-          {
-            "isExternal": true,
-            "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec54aa3535cb70ab8c02996",
-            "title": "Advanced Cluster Management for Kubernetes",
-            "description": "Manage cluster lifecycles, deploy workloads, and enforce policies across your Kubernetes fleet."
-          },
-          {
-            "isExternal": true,
-            "href": "https://catalog.redhat.com/software/container-stacks/detail/5fb288c70a12d20cbecc6056",
-            "title": "OpenShift GitOps",
-            "description": "Build and integrate declarative, Git-driven CD workflows into your application platform."
-          },
-          {
-            "isExternal": true,
-            "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec54a4628834587a6b85ca5",
-            "title": "Pipelines",
-            "description": "Design custom CI/CD pipelines to build, test, and deploy applications."
-          },
-          {
-            "isExternal": true,
-            "href": "https://catalog.redhat.com/software/container-stacks/detail/5ec53e8c110f56bd24f2ddc4",
-            "title": "OpenShift Service Mesh",
-            "description": "Monitor and manage microservices with a unified service mesh."
-          }
-        ]
-      }
-    ]
+    "links": []
   },
   {
     "id": "security",
@@ -709,12 +638,6 @@
         "title": "OpenShift",
         "id": "openshift",
         "links": [
-          {
-            "href": "/openshift/services/rosa/demo/",
-            "title": "ROSA Hands-on Experience",
-            "icon": "OpenShiftIcon",
-            "description": "Access a production-ready ROSA cluster for a limited time in a demo environment."
-          },
           "openshift.developerSandbox",
           "openshift.sixtydaytrial"
         ]


### PR DESCRIPTION
## Summary by Sourcery

Remove local static service definitions and migrate their maintenance to the uhc-portal repository

Enhancements:
- Migrate service tile configurations from cmd/search/static-services-entries.json to uhc-portal
- Migrate static service entries from static/stable/stage/services/services.json to uhc-portal

Chores:
- Delete now-redundant static-services-entries.json
- Delete now-redundant services.json in static/stable/stage/services