### PR TITLE
RHINENG-17223 enabled feoReplacement for ros

### DIFF
--- a/cmd/search/static-services-entries.json
+++ b/cmd/search/static-services-entries.json
@@ -688,26 +688,6 @@
       },
       {
         "custom": true,
-        "id": "RHEL.ros",
-        "title": "Resource Optimization - Business",
-        "href": "/insights/ros",
-        "description": "Optimize your public cloud-based Red Hat Enterprise Linux systems based on CPU, memory, and disk input/output performance.",
-        "alt_title": [
-          "optimization",
-          "optimisation",
-          "optimize",
-          "optimise",
-          "usage",
-          "utilization",
-          "utilisation",
-          "save",
-          "savings",
-          "resource optimization",
-          "resource optimisation"
-        ]
-      },
-      {
-        "custom": true,
         "id": "RHEL.tasks",
         "appId": "tasks",
         "title": "Tasks - Automation",

--- a/static/stable/prod/navigation/insights-navigation.json
+++ b/static/stable/prod/navigation/insights-navigation.json
@@ -580,7 +580,6 @@
           "product": "Red Hat Insights",
           "subtitle": "Red Hat Insights for RHEL",
           "description": "Optimize your public cloud-based Red Hat Enterprise Linux systems based on CPU, memory, and disk input/output performance.",
-          "feoReplacement": "ros",
           "alt_title": [
             "optimization",
             "optimisation",

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -475,13 +475,6 @@
             "href": "/subscriptions/usage/rhel",
             "icon": "OpenShiftIcon",
             "description": "Monitor your Red Hat Enterprise Linux usage for both Annual and On-Demand subscriptions."
-          },
-          {
-            "title": "Resource Optimization",
-            "filterable": false,
-            "href": "/insights/ros",
-            "icon": "OpenShiftIcon",
-            "description": "Optimize your public cloud-based Red Hat Enterprise Linux systems based on CPU, memory, and disk input/output performance."
           }
         ]
       },


### PR DESCRIPTION
Jira: [RHINENG-17223](https://issues.redhat.com/browse/RHINENG-17223)
enabled feoReplacement for ros

## Summary by Sourcery

New Features:
- Enable feoReplacement for ROS in production and staging navigation configuration
- removed ros-rhel entries from the services.json template and from the static static-services-entries.json files.