### PR TITLE
AAP-43377: Admin Dashboard: Frontend Operator Migration

### DIFF
--- a/static/beta/stage/navigation/ansible-navigation.json
+++ b/static/beta/stage/navigation/ansible-navigation.json
@@ -109,6 +109,7 @@
         },
         {
             "title": "Ansible Lightspeed",
+            "feoReplacement": "ansible-wisdom-admin-dashboard-navigation-id",
             "expandable": true,
             "routes": [
                 {

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -55,8 +55,7 @@
             "icon": "AnsibleIcon",
             "description": "Register your Ansible Automation Platform systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
           },
-          "ansible.tasks",
-          "ansible.ansibleWisdomAdminDashboard"
+          "ansible.tasks"
         ]
       }
     ]

--- a/static/stable/stage/navigation/ansible-navigation.json
+++ b/static/stable/stage/navigation/ansible-navigation.json
@@ -110,6 +110,7 @@
         },
         {
             "title": "Ansible Lightspeed",
+            "feoReplacement": "ansible-wisdom-admin-dashboard-navigation-id",
             "expandable": true,
             "routes": [
                 {

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -58,8 +58,7 @@
             "icon": "AnsibleIcon",
             "description": "Register your Ansible Automation Platform systems with the Red Hat Insights Client to view them on the Red Hat Hybrid Cloud Console."
           },
-          "ansible.tasks",
-          "ansible.ansibleWisdomAdminDashboard"
+          "ansible.tasks"
         ]
       }
     ]


### PR DESCRIPTION
[staging] FEO Operator migration

JIRA: https://issues.redhat.com/browse/AAP-43377

This PR:-

- Marks static `NavItems` as "[FEO replaced](https://github.com/RedHatInsights/chrome-service-backend/blob/main/docs/feo-migration-guide.md#4-mark-the-navigation-items-for-replacement-chrome-service-backend-repository)".
- Removes [Service Tiles](https://github.com/RedHatInsights/chrome-service-backend/blob/main/docs/feo-migration-guide.md#services-dropdown-replacement).

## Summary by Sourcery

Implement frontend operator migration for the Admin Dashboard by marking static navigation items as replaced and removing legacy service tiles from the configuration

Enhancements:
- Mark static navigation items in both beta and stable configs as FEO-replaced
- Remove static service tiles entries from services configuration for staging