### PR TITLE
[Bug Fix] Widgets not showing up in itless

### DIFF
--- a/rest/routes/dashboardTemplate.go
+++ b/rest/routes/dashboardTemplate.go
@@ -304,7 +304,7 @@ func FilterWidgetMappingHeaderLink(widgetMapping models.WidgetModuleFederationMa
 
 func FilterWidgetMapping(widgetMapping models.WidgetModuleFederationMapping) models.WidgetModuleFederationMapping {
 	for key, value := range widgetMapping {
-		if !featureflags.IsEnabled(value.FeatureFlag) {
+		if value.FeatureFlag == "" || !featureflags.IsEnabled(value.FeatureFlag) {
 			delete(widgetMapping, key)
 		}
 	}


### PR DESCRIPTION
None of the widgets were showing up in the itless environment. It appears since there are some widgets that do not have a feature flag since the unhandled case was causing issues causing none of the widgets to show up.

## Summary by Sourcery

Bug Fixes:
- Add empty feature flag check in FilterWidgetMapping to properly remove widgets without a defined flag and avoid unhandled cases