### PR TITLE
fix(parseServices): Fix local development errors map of undefined on links in services

### DIFF
--- a/cmd/services/parseServices.go
+++ b/cmd/services/parseServices.go
@@ -95,7 +95,7 @@ func parseServiceItem(tb templateBase, linkStorage *map[string]interface{}) serv
 	serviceItem["icon"] = tb.Icon
 	serviceItem["title"] = tb.Title
 	serviceItem["description"] = tb.Description
-	var serviceItemLinks []interface{}
+	serviceItemLinks := []interface{}{}
 	for _, l := range tb.Links {
 		link := parseServiceItemLink(l, linkStorage)
 		serviceItemLinks = append(serviceItemLinks, link)

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -306,11 +306,6 @@
     ]
   },
   {
-    "id": "operators",
-    "title": "Operators",
-    "links": []
-  },
-  {
     "id": "security",
     "icon": "CloudSecurityIcon",
     "title": "Security",


### PR DESCRIPTION
This is causing one of the errors in the React error boundary locally during development. We've removed the offending service link entry but also updated the script to handle this in the future (will return empty array now in lieu of null)

## Summary by Sourcery

Fix local development errors caused by missing service links by removing the invalid link entry and returning an empty links array instead of null

Bug Fixes:
- Initialize service item links as an empty slice to avoid nil dereference errors
- Remove the offending service link entry from the static services JSON