### PR TITLE
Add feoReplacement to Image Builder

### DIFF
--- a/static/stable/prod/navigation/insights-navigation.json
+++ b/static/stable/prod/navigation/insights-navigation.json
@@ -108,7 +108,8 @@
             "build",
             "assemble",
             "image-builder"
-          ]
+          ],
+          "feoReplacement": "imageBuilder"
         },
         {
           "title": "System Configuration",

--- a/static/stable/stage/navigation/insights-navigation.json
+++ b/static/stable/stage/navigation/insights-navigation.json
@@ -77,7 +77,8 @@
             "build",
             "assemble",
             "image-builder"
-          ]
+          ],
+          "feoReplacement": "imageBuilder"
         },
         {
           "title": "System Configuration",


### PR DESCRIPTION
Migration is done on the side of Image Builder, this adds feoReplacement attribute.

## Summary by Sourcery

Enhancements:
- Introduce feoReplacement property in both production and staging insights navigation definitions for Image Builder.