### PR TITLE
fix: add missing id to content navigation group

### DIFF
--- a/static/stable/prod/navigation/insights-navigation.json
+++ b/static/stable/prod/navigation/insights-navigation.json
@@ -174,6 +174,7 @@
       ]
     },
     {
+      "id": "content",
       "title": "Content",
       "expandable": true,
       "routes": [

--- a/static/stable/stage/navigation/insights-navigation.json
+++ b/static/stable/stage/navigation/insights-navigation.json
@@ -143,6 +143,7 @@
       ]
     },
     {
+      "id": "content",
       "title": "Content",
       "expandable": true,
       "routes": [


### PR DESCRIPTION
This adds missing IDs to the "Content" navigation expandable item in Insights. This is needed as a pre-requisite for FEO migration.

Issue link: [[HMS-5907](https://issues.redhat.com/browse/HMS-5907)]

## Summary by Sourcery

Bug Fixes:
- Add missing id to the Content expandable item in both production and staging Insights navigation JSON