### PR TITLE
Clean up FEO duplication for Cost Management and HCS

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -543,40 +543,6 @@
             "href": "/subscriptions/usage/openshift",
             "icon": "OpenShiftIcon",
             "description": "Drive purchasing and IT operations decisions with comprehensive, account-wide usage reporting of that highlights how and where your technology is being used."
-          },
-          {
-            "title": "Cost Management",
-            "filterable": false,
-            "href": "/openshift/cost-management",
-            "icon": "OpenShiftIcon",
-            "description": "View your data in cost management.",
-            "alt_title": [
-              "cost management",
-              "overview",
-              "cost management oerview",
-              "costmgmt",
-              "cost",
-              "finops",
-              "cost management for openshift",
-              "openshift cost",
-              "rhcm",
-              "finsights",
-              "finops",
-              "spend",
-              "distribute",
-              "cost model",
-              "money",
-              "bill",
-              "billing",
-              "financial",
-              "chargeback",
-              "showback",
-              "rate",
-              "save",
-              "savings",
-              "resource optimization",
-              "resources"
-            ]
           }
         ]
       },
@@ -598,24 +564,6 @@
         "links": [
           "subscriptions.overview",
           "subscriptions.subscriptionsInventory",
-          {
-            "id": "hybridCommittedSpendOverview",
-            "appId": "hybridCommittedSpend",
-            "title": "Hybrid Committed Spend",
-            "icon": "SubscriptionsIcon",
-            "href": "/subscriptions/hybrid-committed-spend",
-            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
-            "permissions": [
-              {
-                "method": "loosePermissions",
-                "args": [
-                  [
-                    "hybrid-committed-spend:reports:read"
-                  ]
-                ]
-              }
-            ]
-          },
           "subscriptions.manifests"
         ]
       }

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -542,40 +542,6 @@
             "href": "/subscriptions/usage/openshift",
             "icon": "OpenShiftIcon",
             "description": "Drive purchasing and IT operations decisions with comprehensive, account-wide usage reporting of that highlights how and where your technology is being used."
-          },
-          {
-            "title": "Cost Management",
-            "filterable": false,
-            "href": "/openshift/cost-management",
-            "icon": "OpenShiftIcon",
-            "description": "View your data in cost management.",
-            "alt_title": [
-              "cost management",
-              "overview",
-              "cost management oerview",
-              "costmgmt",
-              "cost",
-              "finops",
-              "cost management for openshift",
-              "openshift cost",
-              "rhcm",
-              "finsights",
-              "finops",
-              "spend",
-              "distribute",
-              "cost model",
-              "money",
-              "bill",
-              "billing",
-              "financial",
-              "chargeback",
-              "showback",
-              "rate",
-              "save",
-              "savings",
-              "resource optimization",
-              "resources"
-            ]
           }
         ]
       },
@@ -597,24 +563,6 @@
         "links": [
           "subscriptions.overview",
           "subscriptions.subscriptionsInventory",
-          {
-            "id": "hybridCommittedSpendOverview",
-            "appId": "hybridCommittedSpend",
-            "title": "Hybrid Committed Spend",
-            "icon": "SubscriptionsIcon",
-            "href": "/subscriptions/hybrid-committed-spend",
-            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
-            "permissions": [
-              {
-                "method": "loosePermissions",
-                "args": [
-                  [
-                    "hybrid-committed-spend:reports:read"
-                  ]
-                ]
-              }
-            ]
-          },
           "subscriptions.manifests"
         ]
       }

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -508,42 +508,7 @@
         "isGroup": true,
         "title": "OpenShift",
         "id": "openshift",
-        "links": [
-          {
-            "title": "Cost Management",
-            "filterable": false,
-            "href": "/openshift/cost-management",
-            "icon": "OpenShiftIcon",
-            "description": "View your data in cost management.",
-            "alt_title": [
-              "cost management",
-              "overview",
-              "cost management oerview",
-              "costmgmt",
-              "cost",
-              "finops",
-              "cost management for openshift",
-              "openshift cost",
-              "rhcm",
-              "finsights",
-              "finops",
-              "spend",
-              "distribute",
-              "cost model",
-              "money",
-              "bill",
-              "billing",
-              "financial",
-              "chargeback",
-              "showback",
-              "rate",
-              "save",
-              "savings",
-              "resource optimization",
-              "resources"
-            ]
-          }
-        ]
+        "links": []
       },
       {
         "isGroup": true,
@@ -558,24 +523,6 @@
         "links": [
           "subscriptions.overview",
           "subscriptions.subscriptionsInventory",
-          {
-            "id": "hybridCommittedSpendOverview",
-            "appId": "hybridCommittedSpend",
-            "title": "Hybrid Committed Spend",
-            "icon": "SubscriptionsIcon",
-            "href": "/subscriptions/hybrid-committed-spend",
-            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
-            "permissions": [
-              {
-                "method": "loosePermissions",
-                "args": [
-                  [
-                    "hybrid-committed-spend:reports:read"
-                  ]
-                ]
-              }
-            ]
-          },
           "subscriptions.manifests"
         ]
       }

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -449,42 +449,7 @@
         "isGroup": true,
         "title": "OpenShift",
         "id": "openshift",
-        "links": [
-          {
-            "title": "Cost Management",
-            "filterable": false,
-            "href": "/openshift/cost-management",
-            "icon": "OpenShiftIcon",
-            "description": "View your data in cost management.",
-            "alt_title": [
-              "cost management",
-              "overview",
-              "cost management oerview",
-              "costmgmt",
-              "cost",
-              "finops",
-              "cost management for openshift",
-              "openshift cost",
-              "rhcm",
-              "finsights",
-              "finops",
-              "spend",
-              "distribute",
-              "cost model",
-              "money",
-              "bill",
-              "billing",
-              "financial",
-              "chargeback",
-              "showback",
-              "rate",
-              "save",
-              "savings",
-              "resource optimization",
-              "resources"
-            ]
-          }
-        ]
+        "links": []
       },
       {
         "isGroup": true,
@@ -498,25 +463,7 @@
         "id": "subscriptions",
         "links": [
           "subscriptions.subscriptionsInventory",
-          "subscriptions.subscriptionsUsage",
-          {
-            "id": "hybridCommittedSpendOverview",
-            "appId": "hybridCommittedSpend",
-            "title": "Hybrid Committed Spend",
-            "icon": "SubscriptionsIcon",
-            "href": "/subscriptions/hybrid-committed-spend",
-            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
-            "permissions": [
-              {
-                "method": "loosePermissions",
-                "args": [
-                  [
-                    "hybrid-committed-spend:reports:read"
-                  ]
-                ]
-              }
-            ]
-          }
+          "subscriptions.subscriptionsUsage"
         ]
       }
     ]


### PR DESCRIPTION
This is to remove duplicated links seen for Cost Management and HCS

<img width="1599" height="888" alt="Screenshot 2025-09-18 at 10 28 32 AM" src="https://github.com/user-attachments/assets/22d230a1-20ea-47d7-b226-aa8dee9a1b0f" />


## Summary by Sourcery

Remove duplicated service definitions for Cost Management and HCS in static JSON configurations

Bug Fixes:
- Clean up duplicate Cost Management entries in static services JSON for beta and stable environments
- Clean up duplicate HCS entries in static services JSON for beta and stable environments