### PR TITLE
RHCLOUD-42255 - Changing sandbox UI to new external link

### DIFF
--- a/static/beta/prod/navigation/openshift-navigation.json
+++ b/static/beta/prod/navigation/openshift-navigation.json
@@ -241,7 +241,8 @@
               "id": "developersandboxtrial",
               "appId": "openshift",
               "title": "Developer Sandbox | OpenShift AI",
-              "href": "/openshift/sandbox",
+              "href": "https://sandbox.redhat.com",
+              "isExternal": true,
               "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
               "icon": "AITechnologyIcon",
               "filterable": false
@@ -288,7 +289,8 @@
         {
           "id": "developerSandbox",
           "appId": "sandbox",
-          "href": "/openshift/sandbox",
+          "href": "https://sandbox.redhat.com",
+          "isExternal": true,
           "title": "Developer Sandbox",
           "icon": "OpenShiftIcon",
           "filterable": false,

--- a/static/beta/stage/navigation/openshift-navigation.json
+++ b/static/beta/stage/navigation/openshift-navigation.json
@@ -241,7 +241,8 @@
               "id": "developersandboxtrial",
               "appId": "openshift",
               "title": "Developer Sandbox | OpenShift AI",
-              "href": "/openshift/sandbox",
+              "href": "https://sandbox.redhat.com",
+              "isExternal": true,
               "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
               "icon": "AITechnologyIcon",
               "filterable": false
@@ -288,7 +289,8 @@
         {
           "id": "developerSandbox",
           "appId": "sandbox",
-          "href": "/openshift/sandbox",
+          "href": "https://sandbox.redhat.com",
+          "isExternal": true,
           "title": "Developer Sandbox",
           "icon": "OpenShiftIcon",
           "filterable": false,

--- a/static/stable/prod/navigation/openshift-navigation.json
+++ b/static/stable/prod/navigation/openshift-navigation.json
@@ -253,7 +253,8 @@
               "id": "developersandboxtrial",
               "appId": "openshift",
               "title": "Developer Sandbox | OpenShift AI",
-              "href": "/openshift/sandbox",
+              "href": "https://sandbox.redhat.com",
+              "isExternal": true,
               "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
               "icon": "AITechnologyIcon",
               "filterable": false
@@ -301,7 +302,8 @@
         {
           "id": "developerSandbox",
           "appId": "sandbox",
-          "href": "/openshift/sandbox",
+          "href": "https://sandbox.redhat.com",
+          "isExternal": true,
           "title": "Developer Sandbox",
           "icon": "OpenShiftIcon",
           "filterable": false,

--- a/static/stable/stage/navigation/openshift-navigation.json
+++ b/static/stable/stage/navigation/openshift-navigation.json
@@ -256,7 +256,8 @@
               "id": "developersandboxtrial",
               "appId": "openshift",
               "title": "Developer Sandbox | OpenShift AI",
-              "href": "/openshift/sandbox",
+              "href": "https://sandbox.redhat.com",
+              "isExternal": true,
               "description": "Create, train, and service artificial intelligence and machine learning (AI/ML) models.",
               "icon": "AITechnologyIcon",
               "filterable": false
@@ -305,7 +306,8 @@
         {
           "id": "developerSandbox",
           "appId": "sandbox",
-          "href": "/openshift/sandbox",
+          "href": "https://sandbox.redhat.com",
+          "isExternal": true,
           "title": "Developer Sandbox",
           "icon": "OpenShiftIcon",
           "filterable": false,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-42255

## Summary by Sourcery

Enhancements:
- Changed the sandbox UI link in openshift-navigation.json to the new external URL for both beta and stable channels in prod and stage