### PR TITLE
Revert changes to clean up Cost Management and HCS

### DIFF
--- a/static/beta/prod/services/services.json
+++ b/static/beta/prod/services/services.json
@@ -543,6 +543,40 @@
             "href": "/subscriptions/usage/openshift",
             "icon": "OpenShiftIcon",
             "description": "Drive purchasing and IT operations decisions with comprehensive, account-wide usage reporting of that highlights how and where your technology is being used."
+          },
+          {
+            "title": "Cost Management",
+            "filterable": false,
+            "href": "/openshift/cost-management",
+            "icon": "OpenShiftIcon",
+            "description": "View your data in cost management.",
+            "alt_title": [
+              "cost management",
+              "overview",
+              "cost management oerview",
+              "costmgmt",
+              "cost",
+              "finops",
+              "cost management for openshift",
+              "openshift cost",
+              "rhcm",
+              "finsights",
+              "finops",
+              "spend",
+              "distribute",
+              "cost model",
+              "money",
+              "bill",
+              "billing",
+              "financial",
+              "chargeback",
+              "showback",
+              "rate",
+              "save",
+              "savings",
+              "resource optimization",
+              "resources"
+            ]
           }
         ]
       },
@@ -564,6 +598,24 @@
         "links": [
           "subscriptions.overview",
           "subscriptions.subscriptionsInventory",
+          {
+            "id": "hybridCommittedSpendOverview",
+            "appId": "hybridCommittedSpend",
+            "title": "Hybrid Committed Spend",
+            "icon": "SubscriptionsIcon",
+            "href": "/subscriptions/hybrid-committed-spend",
+            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
+            "permissions": [
+              {
+                "method": "loosePermissions",
+                "args": [
+                  [
+                    "hybrid-committed-spend:reports:read"
+                  ]
+                ]
+              }
+            ]
+          },
           "subscriptions.manifests"
         ]
       }

--- a/static/beta/stage/services/services.json
+++ b/static/beta/stage/services/services.json
@@ -542,6 +542,40 @@
             "href": "/subscriptions/usage/openshift",
             "icon": "OpenShiftIcon",
             "description": "Drive purchasing and IT operations decisions with comprehensive, account-wide usage reporting of that highlights how and where your technology is being used."
+          },
+          {
+            "title": "Cost Management",
+            "filterable": false,
+            "href": "/openshift/cost-management",
+            "icon": "OpenShiftIcon",
+            "description": "View your data in cost management.",
+            "alt_title": [
+              "cost management",
+              "overview",
+              "cost management oerview",
+              "costmgmt",
+              "cost",
+              "finops",
+              "cost management for openshift",
+              "openshift cost",
+              "rhcm",
+              "finsights",
+              "finops",
+              "spend",
+              "distribute",
+              "cost model",
+              "money",
+              "bill",
+              "billing",
+              "financial",
+              "chargeback",
+              "showback",
+              "rate",
+              "save",
+              "savings",
+              "resource optimization",
+              "resources"
+            ]
           }
         ]
       },
@@ -563,6 +597,24 @@
         "links": [
           "subscriptions.overview",
           "subscriptions.subscriptionsInventory",
+          {
+            "id": "hybridCommittedSpendOverview",
+            "appId": "hybridCommittedSpend",
+            "title": "Hybrid Committed Spend",
+            "icon": "SubscriptionsIcon",
+            "href": "/subscriptions/hybrid-committed-spend",
+            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
+            "permissions": [
+              {
+                "method": "loosePermissions",
+                "args": [
+                  [
+                    "hybrid-committed-spend:reports:read"
+                  ]
+                ]
+              }
+            ]
+          },
           "subscriptions.manifests"
         ]
       }

--- a/static/stable/prod/services/services.json
+++ b/static/stable/prod/services/services.json
@@ -508,7 +508,42 @@
         "isGroup": true,
         "title": "OpenShift",
         "id": "openshift",
-        "links": []
+        "links": [
+          {
+            "title": "Cost Management",
+            "filterable": false,
+            "href": "/openshift/cost-management",
+            "icon": "OpenShiftIcon",
+            "description": "View your data in cost management.",
+            "alt_title": [
+              "cost management",
+              "overview",
+              "cost management oerview",
+              "costmgmt",
+              "cost",
+              "finops",
+              "cost management for openshift",
+              "openshift cost",
+              "rhcm",
+              "finsights",
+              "finops",
+              "spend",
+              "distribute",
+              "cost model",
+              "money",
+              "bill",
+              "billing",
+              "financial",
+              "chargeback",
+              "showback",
+              "rate",
+              "save",
+              "savings",
+              "resource optimization",
+              "resources"
+            ]
+          }
+        ]
       },
       {
         "isGroup": true,
@@ -523,6 +558,24 @@
         "links": [
           "subscriptions.overview",
           "subscriptions.subscriptionsInventory",
+          {
+            "id": "hybridCommittedSpendOverview",
+            "appId": "hybridCommittedSpend",
+            "title": "Hybrid Committed Spend",
+            "icon": "SubscriptionsIcon",
+            "href": "/subscriptions/hybrid-committed-spend",
+            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
+            "permissions": [
+              {
+                "method": "loosePermissions",
+                "args": [
+                  [
+                    "hybrid-committed-spend:reports:read"
+                  ]
+                ]
+              }
+            ]
+          },
           "subscriptions.manifests"
         ]
       }

--- a/static/stable/stage/services/services.json
+++ b/static/stable/stage/services/services.json
@@ -449,7 +449,42 @@
         "isGroup": true,
         "title": "OpenShift",
         "id": "openshift",
-        "links": []
+        "links": [
+          {
+            "title": "Cost Management",
+            "filterable": false,
+            "href": "/openshift/cost-management",
+            "icon": "OpenShiftIcon",
+            "description": "View your data in cost management.",
+            "alt_title": [
+              "cost management",
+              "overview",
+              "cost management oerview",
+              "costmgmt",
+              "cost",
+              "finops",
+              "cost management for openshift",
+              "openshift cost",
+              "rhcm",
+              "finsights",
+              "finops",
+              "spend",
+              "distribute",
+              "cost model",
+              "money",
+              "bill",
+              "billing",
+              "financial",
+              "chargeback",
+              "showback",
+              "rate",
+              "save",
+              "savings",
+              "resource optimization",
+              "resources"
+            ]
+          }
+        ]
       },
       {
         "isGroup": true,
@@ -463,7 +498,25 @@
         "id": "subscriptions",
         "links": [
           "subscriptions.subscriptionsInventory",
-          "subscriptions.subscriptionsUsage"
+          "subscriptions.subscriptionsUsage",
+          {
+            "id": "hybridCommittedSpendOverview",
+            "appId": "hybridCommittedSpend",
+            "title": "Hybrid Committed Spend",
+            "icon": "SubscriptionsIcon",
+            "href": "/subscriptions/hybrid-committed-spend",
+            "description": "Gain perspective on your hybrid committed spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.",
+            "permissions": [
+              {
+                "method": "loosePermissions",
+                "args": [
+                  [
+                    "hybrid-committed-spend:reports:read"
+                  ]
+                ]
+              }
+            ]
+          }
         ]
       }
     ]


### PR DESCRIPTION
Cost Management links are missing from the "Subscriptions and Spend" pane in prod. This PR reverts the previous change to clean up link duplication.

FYI @Hyperkid123

<img width="1315" height="826" alt="Screenshot 2025-09-22 at 2 53 14 PM" src="https://github.com/user-attachments/assets/99877408-f5c7-4e58-99c2-7568849f2c5f" />

## Summary by Sourcery

Revert the previous cleanup that removed FEO duplicate entries and restore the missing Cost Management and HCS navigation links across all service listings in both beta and stable environments for stage and production.

Bug Fixes:
- Restore missing Cost Management navigation links in the "all services" pane
- Reintroduce HCS navigation links