### PR TITLE
collect api spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN CGO_ENABLED=1 go build -o /go/bin/chrome-migrate cmd/migrate/migrate.go
 # Build the search index binary.
 RUN CGO_ENABLED=1 go build -o /go/bin/chrome-search-index cmd/search/publishSearchIndex.go
 
+# Build the fetch specs binary.
+RUN CGO_ENABLED=1 go build -o /go/bin/chrome-fetch-specs cmd/fetchSpecs/fetchSpecs.go
+
 # Pin to a specific version rather than :latest for reproducible builds and to prevent unintended changes
 FROM registry.access.redhat.com/ubi9-minimal:9.7-1773204619@sha256:69f5c9886ecb19b23e88275a5cd904c47dd982dfa370fbbd0c356d7b1047ef68
 
@@ -38,6 +41,7 @@ RUN chgrp -R 0 /static && \
 COPY --from=builder   /go/bin/chrome-service-backend /app/chrome-service-backend
 COPY --from=builder /go/bin/chrome-migrate /usr/bin
 COPY --from=builder /go/bin/chrome-search-index /usr/bin
+COPY --from=builder /go/bin/chrome-fetch-specs /usr/bin
 # Copy chrome static JSON assets to server binary entry point
 COPY --from=builder $GOPATH/src/chrome-service-backend/static /static
 # Copy widget dashboard defaults to server binary entry point

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ help:
 	@echo "  - port: http server port 'make dev-static-node port=8888'"
 	@echo "audit 		 	- run grype audit on the docker image"
 	@echo "generate-search-index 	- generate search index"
+	@echo "fetch-specs           	- fetch OpenAPI specs into static/specs-generated.json (FEO_API_SPEC)"
 
 port?=8000
 ENV_FILE?=.env
@@ -55,6 +56,9 @@ generate-search-index: export SEARCH_INDEX_WRITE = true
 
 generate-search-index:
 	go run cmd/search/*
+
+fetch-specs:
+	go run cmd/fetchSpecs/fetchSpecs.go
 
 kafka:
 	podman-compose --env-file $(PWD)/$(ENV_FILE) -f $(PWD)/local/kafka-compose.yaml up

--- a/cmd/fetchSpecs/fetchSpecs.go
+++ b/cmd/fetchSpecs/fetchSpecs.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/joho/godotenv"
+)
+
+const (
+	defaultOutputPath = "static/specs-generated.json"
+	envFEOAPISpec     = "FEO_API_SPEC"
+	envOutputPath     = "FETCH_SPECS_TARGET"
+	envHTTPTimeout    = "FETCH_SPECS_TIMEOUT"
+	defaultTimeout    = 60 * time.Second
+	maxBodySize       = 32 << 20 // 32MB
+)
+
+// apiSpecInput matches FEO_API_SPEC / frontend-operator APISpecInfo (see frontend_types.go).
+type apiSpecInput struct {
+	URL          string   `json:"url"`
+	BundleLabels []string `json:"bundleLabels"`
+	FrontendName string   `json:"frontendName"`
+}
+
+// specOutputEntry is one resolved OpenAPI document plus metadata from the index.
+type specOutputEntry struct {
+	URL          string          `json:"url"`
+	BundleLabels []string        `json:"bundleLabels"`
+	Spec         json.RawMessage `json:"spec"`
+}
+
+func main() {
+	_ = godotenv.Load()
+
+	outputPath := getOutputPath()
+	timeout := getHTTPTimeout()
+
+	raw := os.Getenv(envFEOAPISpec)
+	if raw == "" {
+		fmt.Fprintf(os.Stderr, "%s is not set; writing empty object to %s\n", envFEOAPISpec, outputPath)
+		if err := writeOutput(outputPath, map[string][]specOutputEntry{}); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write output: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	var entries []apiSpecInput
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid %s JSON: %v\n", envFEOAPISpec, err)
+		os.Exit(1)
+	}
+
+	out := make(map[string][]specOutputEntry)
+	client := &http.Client{Timeout: timeout}
+
+	for _, e := range entries {
+		if e.URL == "" {
+			fmt.Fprintf(os.Stderr, "skipping entry with empty url (frontendName=%q)\n", e.FrontendName)
+			continue
+		}
+		if e.FrontendName == "" {
+			fmt.Fprintf(os.Stderr, "skipping entry with empty frontendName (url=%q)\n", e.URL)
+			continue
+		}
+
+		body, status, err := fetchURL(client, e.URL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fetch failed for %q: %v\n", e.URL, err)
+			continue
+		}
+		if status < 200 || status >= 300 {
+			fmt.Fprintf(os.Stderr, "fetch failed for %q: HTTP %d\n", e.URL, status)
+			continue
+		}
+
+		if !json.Valid(body) {
+			fmt.Fprintf(os.Stderr, "response is not valid JSON for %q; skipping\n", e.URL)
+			continue
+		}
+
+		out[e.FrontendName] = append(out[e.FrontendName], specOutputEntry{
+			URL:          e.URL,
+			BundleLabels: e.BundleLabels,
+			Spec:         json.RawMessage(body),
+		})
+	}
+
+	if err := writeOutput(outputPath, out); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write output: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Wrote %s (%d frontend keys)\n", outputPath, len(out))
+}
+
+func getOutputPath() string {
+	if path := os.Getenv(envOutputPath); path != "" {
+		return path
+	}
+	return defaultOutputPath
+}
+
+func getHTTPTimeout() time.Duration {
+	if timeoutStr := os.Getenv(envHTTPTimeout); timeoutStr != "" {
+		if seconds, err := strconv.Atoi(timeoutStr); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return defaultTimeout
+}
+
+func fetchURL(client *http.Client, url string) ([]byte, int, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxBodySize))
+	if err != nil {
+		return nil, res.StatusCode, err
+	}
+	return body, res.StatusCode, nil
+}
+
+func writeOutput(outputPath string, data map[string][]specOutputEntry) error {
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(cwd, outputPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, encoded, 0o644)
+}

--- a/cmd/fetchSpecs/fetchSpecs_test.go
+++ b/cmd/fetchSpecs/fetchSpecs_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGetOutputPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     string
+	}{
+		{
+			name:     "uses default when env not set",
+			envValue: "",
+			want:     defaultOutputPath,
+		},
+		{
+			name:     "uses env value when set",
+			envValue: "custom/path/specs.json",
+			want:     "custom/path/specs.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(envOutputPath, tt.envValue)
+				defer os.Unsetenv(envOutputPath)
+			} else {
+				os.Unsetenv(envOutputPath)
+			}
+
+			got := getOutputPath()
+			if got != tt.want {
+				t.Errorf("getOutputPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetHTTPTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     time.Duration
+	}{
+		{
+			name:     "uses default when env not set",
+			envValue: "",
+			want:     defaultTimeout,
+		},
+		{
+			name:     "uses env value when set to valid number",
+			envValue: "30",
+			want:     30 * time.Second,
+		},
+		{
+			name:     "uses default when env value is invalid",
+			envValue: "invalid",
+			want:     defaultTimeout,
+		},
+		{
+			name:     "uses default when env value is negative",
+			envValue: "-10",
+			want:     defaultTimeout,
+		},
+		{
+			name:     "uses default when env value is zero",
+			envValue: "0",
+			want:     defaultTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(envHTTPTimeout, tt.envValue)
+				defer os.Unsetenv(envHTTPTimeout)
+			} else {
+				os.Unsetenv(envHTTPTimeout)
+			}
+
+			got := getHTTPTimeout()
+			if got != tt.want {
+				t.Errorf("getHTTPTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseBody   string
+		responseStatus int
+		wantStatus     int
+		wantErr        bool
+		wantBodyEmpty  bool
+	}{
+		{
+			name:           "successful fetch with valid JSON",
+			responseBody:   `{"openapi":"3.0.0"}`,
+			responseStatus: http.StatusOK,
+			wantStatus:     http.StatusOK,
+			wantErr:        false,
+			wantBodyEmpty:  false,
+		},
+		{
+			name:           "handles 404 response",
+			responseBody:   "not found",
+			responseStatus: http.StatusNotFound,
+			wantStatus:     http.StatusNotFound,
+			wantErr:        false,
+			wantBodyEmpty:  false,
+		},
+		{
+			name:           "handles 500 response",
+			responseBody:   "internal error",
+			responseStatus: http.StatusInternalServerError,
+			wantStatus:     http.StatusInternalServerError,
+			wantErr:        false,
+			wantBodyEmpty:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Accept") != "application/json" {
+					t.Errorf("Expected Accept header to be 'application/json', got '%s'", r.Header.Get("Accept"))
+				}
+				w.WriteHeader(tt.responseStatus)
+				w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			client := &http.Client{Timeout: 5 * time.Second}
+			body, status, err := fetchURL(client, server.URL)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fetchURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if status != tt.wantStatus {
+				t.Errorf("fetchURL() status = %v, want %v", status, tt.wantStatus)
+			}
+
+			if tt.wantBodyEmpty && len(body) > 0 {
+				t.Errorf("fetchURL() body should be empty, got %d bytes", len(body))
+			}
+
+			if !tt.wantBodyEmpty && len(body) == 0 {
+				t.Errorf("fetchURL() body should not be empty")
+			}
+		})
+	}
+}
+
+func TestFetchURLTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	_, _, err := fetchURL(client, server.URL)
+
+	if err == nil {
+		t.Error("fetchURL() should timeout but didn't return error")
+	}
+}
+
+func TestWriteOutput(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Change to temp directory so writeOutput's filepath.Abs(".") works correctly
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer os.Chdir(originalWd)
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+
+	outputPath := "test-specs.json"
+
+	testData := map[string][]specOutputEntry{
+		"test-service": {
+			{
+				URL:          "https://example.com/api/v1/openapi.json",
+				BundleLabels: []string{"test"},
+				Spec:         json.RawMessage(`{"openapi":"3.0.0"}`),
+			},
+		},
+	}
+
+	err = writeOutput(outputPath, testData)
+	if err != nil {
+		t.Fatalf("writeOutput() error = %v", err)
+	}
+
+	fullPath := filepath.Join(tempDir, outputPath)
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		t.Errorf("writeOutput() did not create file at %s", fullPath)
+	}
+
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+
+	var result map[string][]specOutputEntry
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("output file contains invalid JSON: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 service, got %d", len(result))
+	}
+
+	if _, ok := result["test-service"]; !ok {
+		t.Error("expected 'test-service' key in result")
+	}
+}
+
+func TestWriteOutputCreatesDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Change to temp directory so writeOutput's filepath.Abs(".") works correctly
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer os.Chdir(originalWd)
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+
+	outputPath := "nested/dir/specs.json"
+
+	testData := map[string][]specOutputEntry{}
+
+	err = writeOutput(outputPath, testData)
+	if err != nil {
+		t.Fatalf("writeOutput() error = %v", err)
+	}
+
+	fullPath := filepath.Join(tempDir, outputPath)
+	if _, err := os.Stat(filepath.Dir(fullPath)); os.IsNotExist(err) {
+		t.Error("writeOutput() did not create parent directories")
+	}
+}
+
+func TestAPISpecInputValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry apiSpecInput
+		valid bool
+	}{
+		{
+			name: "valid entry",
+			entry: apiSpecInput{
+				URL:          "https://example.com/api.json",
+				FrontendName: "test-service",
+				BundleLabels: []string{"test"},
+			},
+			valid: true,
+		},
+		{
+			name: "empty URL",
+			entry: apiSpecInput{
+				URL:          "",
+				FrontendName: "test-service",
+			},
+			valid: false,
+		},
+		{
+			name: "empty frontendName",
+			entry: apiSpecInput{
+				URL:          "https://example.com/api.json",
+				FrontendName: "",
+			},
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isValid := tt.entry.URL != "" && tt.entry.FrontendName != ""
+			if isValid != tt.valid {
+				t.Errorf("validation = %v, want %v", isValid, tt.valid)
+			}
+		})
+	}
+}

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -191,6 +191,54 @@ objects:
               cpu: ${CPU_REQUEST_CHROME_SERVICE}
               memory: ${MEMORY_REQUEST_CHROME_SERVICE}
 
+  # CronJob to fetch and update OpenAPI specs
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: chrome-fetch-specs
+      labels:
+        app: chrome-service
+    spec:
+      schedule: ${FETCH_SPECS_SCHEDULE}
+      suspend: ${{FETCH_SPECS_SUSPEND}}
+      concurrencyPolicy: "Forbid"
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 3
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app: chrome-service
+                job: fetch-specs
+            spec:
+              restartPolicy: OnFailure
+              containers:
+              - name: fetch-specs
+                image: ${IMAGE}:${IMAGE_TAG}
+                command:
+                  - /bin/bash
+                  - -c
+                  - chrome-fetch-specs
+                env:
+                - name: FEO_API_SPEC
+                  valueFrom:
+                    configMapKeyRef:
+                      key: api-specs.json
+                      name: ${FRONTEND_CONTEXT_NAME}
+                      optional: true
+                - name: FETCH_SPECS_TARGET
+                  value: ${FETCH_SPECS_TARGET}
+                - name: FETCH_SPECS_TIMEOUT
+                  value: ${FETCH_SPECS_TIMEOUT}
+                resources:
+                  limits:
+                    cpu: ${CPU_LIMIT_FETCH_SPECS}
+                    memory: ${MEMORY_LIMIT_FETCH_SPECS}
+                  requests:
+                    cpu: ${CPU_REQUEST_FETCH_SPECS}
+                    memory: ${MEMORY_REQUEST_FETCH_SPECS}
+
   # This is a dummy secret to make ephemeral deploy correctly. It will not roll out to stage or prod
   # Unless we set "secret" in "managedResourceTypes" in the app-interface saas file.
   - apiVersion: v1
@@ -255,3 +303,30 @@ parameters:
 - description: Bundles navigation fully onboarded to FEO
   name: FEO_BUNDLES_ONBOARDED_IDS
   value: '["user-preferences"]'
+- description: Enable or disable clowder
+  name: CLOWDER_ENABLED
+  value: 'true'
+- description: Schedule for fetching OpenAPI specs (cron format or @hourly, @daily)
+  name: FETCH_SPECS_SCHEDULE
+  value: "@daily"
+- description: Suspend the fetch-specs CronJob (true to disable)
+  name: FETCH_SPECS_SUSPEND
+  value: 'false'
+- description: Output path for fetched specs
+  name: FETCH_SPECS_TARGET
+  value: "static/specs-generated.json"
+- description: HTTP timeout for fetching specs in seconds
+  name: FETCH_SPECS_TIMEOUT
+  value: "60"
+- description: CPU limit for fetch-specs CronJob
+  name: CPU_LIMIT_FETCH_SPECS
+  value: 200m
+- description: Memory limit for fetch-specs CronJob
+  name: MEMORY_LIMIT_FETCH_SPECS
+  value: 256Mi
+- description: CPU request for fetch-specs CronJob
+  name: CPU_REQUEST_FETCH_SPECS
+  value: 100m
+- description: Memory request for fetch-specs CronJob
+  name: MEMORY_REQUEST_FETCH_SPECS
+  value: 128Mi


### PR DESCRIPTION
collect api spec

[RHCLOUD-37864](https://redhat.atlassian.net/jira/software/c/projects/RHCLOUD/boards/9703?selectedIssue=RHCLOUD-37864)

[RHCLOUD-37864]: https://redhat.atlassian.net/browse/RHCLOUD-37864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce a scheduled job and tooling to collect OpenAPI specifications into a generated static file for the chrome service.

New Features:
- Add a fetch-specs Go command that aggregates configured OpenAPI specs into a JSON file for frontends.
- Expose a make target to run the spec fetching command locally.
- Add a Kubernetes CronJob to periodically run the fetch-specs command in the chrome-service environment.

Enhancements:
- Extend the container image to include the new fetch-specs binary.
- Make the output path, input spec list, and HTTP timeout configurable via environment and deployment parameters.

Tests:
- Add unit tests covering configuration, HTTP fetching behavior, output writing, and basic validation for the spec fetching command.