### PR TITLE
Add GET /api/chrome-service/v1/api-docs endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 		subrouter.Route("/user", routes.MakeUserIdentityRoutes)
 		subrouter.Route("/emit-message", routes.BroadcastMessage)
 		subrouter.Route("/dashboard-templates", routes.MakeDashboardTemplateRoutes)
+		subrouter.Route("/api-docs", routes.MakeApiDocsRoutes)
 	})
 
 	// We might want to set up some event listeners at some point, but the pod will

--- a/rest/routes/apiDocs.go
+++ b/rest/routes/apiDocs.go
@@ -1,0 +1,93 @@
+package routes
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+
+	"github.com/RedHatInsights/chrome-service-backend/rest/util"
+	"github.com/go-chi/chi/v5"
+	"github.com/sirupsen/logrus"
+)
+
+const specsFilePath = "static/specs-generated.json"
+
+type apiDocEntry struct {
+	URL          string          `json:"url"`
+	BundleLabels []string        `json:"bundleLabels"`
+	Spec         json.RawMessage `json:"spec"`
+}
+
+func GetApiDocs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "max-age=3600")
+
+	bundleFilter := r.URL.Query().Get("bundle")
+
+	if bundleFilter == "" {
+		serveSpecsFile(w)
+		return
+	}
+
+	serveFilteredSpecs(w, bundleFilter)
+}
+
+func serveSpecsFile(w http.ResponseWriter) {
+	f, err := os.Open(specsFilePath)
+	if err != nil {
+		handleFileError(w, err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(w, f); err != nil {
+		logrus.Errorf("failed to stream specs file %s: %v", specsFilePath, err)
+	}
+}
+
+func serveFilteredSpecs(w http.ResponseWriter, bundle string) {
+	data, err := os.ReadFile(specsFilePath)
+	if err != nil {
+		handleFileError(w, err)
+		return
+	}
+
+	var allSpecs map[string][]apiDocEntry
+	if err := json.Unmarshal(data, &allSpecs); err != nil {
+		logrus.Errorf("failed to parse specs file %s: %v", specsFilePath, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(util.ErrorResponse{Errors: []string{"failed to parse specs file"}})
+		return
+	}
+
+	filtered := make(map[string][]apiDocEntry)
+	for name, entries := range allSpecs {
+		for _, entry := range entries {
+			if slices.Contains(entry.BundleLabels, bundle) {
+				filtered[name] = append(filtered[name], entry)
+			}
+		}
+	}
+
+	json.NewEncoder(w).Encode(filtered)
+}
+
+func handleFileError(w http.ResponseWriter, err error) {
+	if errors.Is(err, os.ErrNotExist) {
+		logrus.Warnf("specs file not found at %s, returning empty object", specsFilePath)
+		if _, writeErr := w.Write([]byte("{}")); writeErr != nil {
+			logrus.Errorf("failed to write fallback response: %v", writeErr)
+		}
+		return
+	}
+	logrus.Errorf("failed to open specs file %s: %v", specsFilePath, err)
+	w.WriteHeader(http.StatusInternalServerError)
+	json.NewEncoder(w).Encode(util.ErrorResponse{Errors: []string{"failed to read specs file"}})
+}
+
+func MakeApiDocsRoutes(sub chi.Router) {
+	sub.Get("/", GetApiDocs)
+}

--- a/rest/routes/apiDocs_test.go
+++ b/rest/routes/apiDocs_test.go
@@ -1,0 +1,190 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func withTempDir(t *testing.T, fn func()) {
+	t.Helper()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer os.Chdir(originalWd)
+
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	fn()
+}
+
+func writeSpecsFile(t *testing.T, content string) {
+	t.Helper()
+	if err := os.MkdirAll("static", 0o755); err != nil {
+		t.Fatalf("failed to create static directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("static", "specs-generated.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write specs file: %v", err)
+	}
+}
+
+func TestGetApiDocsSuccess(t *testing.T) {
+	withTempDir(t, func() {
+		expected := `{"notifications":[{"url":"https://example.com/api/v1/openapi.json","bundleLabels":["settings"],"spec":{"openapi":"3.0.0"}}]}`
+		writeSpecsFile(t, expected)
+
+		request, _ := http.NewRequest("GET", "/api-docs", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.JSONEq(t, expected, recorder.Body.String())
+	})
+}
+
+func TestGetApiDocsFileNotFound(t *testing.T) {
+	withTempDir(t, func() {
+		request, _ := http.NewRequest("GET", "/api-docs", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "{}", recorder.Body.String())
+	})
+}
+
+func TestGetApiDocsContentType(t *testing.T) {
+	withTempDir(t, func() {
+		writeSpecsFile(t, `{"rbac":[]}`)
+
+		request, _ := http.NewRequest("GET", "/api-docs", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+	})
+}
+
+func TestGetApiDocsReadError(t *testing.T) {
+	// chmod 0o000 has no effect when running as root (e.g. in CI containers)
+	if os.Getuid() == 0 {
+		t.Skip("skipping permission test when running as root")
+	}
+
+	withTempDir(t, func() {
+		writeSpecsFile(t, "test")
+		os.Chmod(filepath.Join("static", "specs-generated.json"), 0o000)
+
+		request, _ := http.NewRequest("GET", "/api-docs", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+		var errResp map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &errResp)
+		assert.NoError(t, err)
+		_, hasErrors := errResp["errors"]
+		assert.True(t, hasErrors, "response should contain errors field")
+	})
+}
+
+func TestGetApiDocsBundleFilter(t *testing.T) {
+	withTempDir(t, func() {
+		specsJSON := `{
+			"notifications":[{"url":"https://example.com/notifications/v1","bundleLabels":["settings"],"spec":{}}],
+			"rbac":[{"url":"https://example.com/rbac/v1","bundleLabels":["iam"],"spec":{}}],
+			"sources":[
+				{"url":"https://example.com/integrations/v1","bundleLabels":["settings"],"spec":{}},
+				{"url":"https://example.com/sources/v3","bundleLabels":["insights"],"spec":{}}
+			]
+		}`
+		writeSpecsFile(t, specsJSON)
+
+		request, _ := http.NewRequest("GET", "/api-docs?bundle=settings", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		var result map[string][]apiDocEntry
+		err := json.Unmarshal(recorder.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		assert.Len(t, result, 2, "should return only frontends with settings bundle")
+		assert.Len(t, result["notifications"], 1)
+		assert.Len(t, result["sources"], 1)
+		assert.Equal(t, "https://example.com/integrations/v1", result["sources"][0].URL)
+		_, hasRbac := result["rbac"]
+		assert.False(t, hasRbac, "rbac should be excluded (iam bundle only)")
+	})
+}
+
+func TestGetApiDocsBundleFilterNoMatch(t *testing.T) {
+	withTempDir(t, func() {
+		writeSpecsFile(t, `{"notifications":[{"url":"https://example.com","bundleLabels":["settings"],"spec":{}}]}`)
+
+		request, _ := http.NewRequest("GET", "/api-docs?bundle=nonexistent", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.JSONEq(t, `{}`, recorder.Body.String())
+	})
+}
+
+func TestGetApiDocsCacheControlHeader(t *testing.T) {
+	withTempDir(t, func() {
+		writeSpecsFile(t, `{}`)
+
+		request, _ := http.NewRequest("GET", "/api-docs", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, "max-age=3600", recorder.Header().Get("Cache-Control"))
+	})
+}
+
+func TestGetApiDocsNoResponseWrapper(t *testing.T) {
+	withTempDir(t, func() {
+		writeSpecsFile(t, `{"svc":[{"url":"https://example.com","bundleLabels":["test"],"spec":{}}]}`)
+
+		request, _ := http.NewRequest("GET", "/api-docs", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(GetApiDocs)
+		handler.ServeHTTP(recorder, request)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &result)
+		assert.NoError(t, err)
+
+		_, hasData := result["data"]
+		assert.False(t, hasData, "response should not be wrapped in {\"data\": ...}")
+
+		_, hasSvc := result["svc"]
+		assert.True(t, hasSvc, "response should contain raw file content")
+	})
+}


### PR DESCRIPTION
### Description
## Summary

Add a new authenticated endpoint `GET /api/chrome-service/v1/api-docs` that serves aggregated OpenAPI specifications to the frontend Help Panel component.

## Changes

- **rest/routes/apiDocs.go** — New route handler that reads `static/specs-generated.json` from disk and returns raw JSON content. Returns `{}` if the file has not been generated yet.
- **rest/routes/apiDocs_test.go** — Unit tests covering success path, file-not-found fallback, Content-Type header, and verification that the response is not wrapped in an EntityResponse envelope.
- **main.go** — Register `/api-docs` route in the authenticated subrouter.

## Context

The CronJob implemented in RHCLOUD-37864 already generates `specs-generated.json` daily on stage. This PR adds the HTTP endpoint that exposes that data to the frontend. The response is served as raw JSON with no deserialization or transformation — the file content is streamed directly to the client.

## Related

- Jira: https://redhat.atlassian.net/browse/RHCLOUD-47439
- CronJob PR: https://github.com/RedHatInsights/chrome-service-backend/pull/1054

---

### Checklist
- [x] Tests: new/updated tests cover the change
- [x] API: spec updated if endpoints changed (or N/A)
- [x] Migrations: backwards compatible if schema changed (or N/A)
- [x] Dependencies: no known impact to dependent services
- [x] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->

## Summary by Sourcery

Expose an authenticated API endpoint that serves pre-generated OpenAPI documentation as raw JSON to clients.

New Features:
- Add a new authenticated /api-docs route that streams the contents of static/specs-generated.json without additional wrapping.

Tests:
- Introduce unit tests verifying successful spec retrieval, file-not-found fallback behavior, JSON content type, and absence of response envelope wrapping.