### PR TITLE
SWATCH-5049: List rhsm-subscriptions v2 in console API docs config

### DIFF
--- a/static/beta/stage/main.yml
+++ b/static/beta/stage/main.yml
@@ -242,6 +242,7 @@ subscriptions:
   title: Subscriptions
   api:
     versions:
+      - v2
       - v1
     alias:
       - rhsm-subscriptions

--- a/static/stable/stage/main.yml
+++ b/static/stable/stage/main.yml
@@ -325,6 +325,7 @@ subscriptions:
   title: Subscriptions
   api:
     versions:
+      - v2
       - v1
     alias:
       - rhsm-subscriptions


### PR DESCRIPTION
Add v2 before v1 under subscriptions.api.versions in chrome-service-backend main.yml, same pattern as compliance and other multi-version console APIs.
Same change on prod will be proposed on the next SWATCH prod release.

### Description
<!-- Summary of proposed changes: what and why. -->

[SWATCH-5049](https://issues.redhat.com/browse/SWATCH-5049)


### Checklist
- [ ] Tests: N/A — static main.yml only; no main.yml test/schema in repo; CI runs validate-schema + go test
- [x] API: N/A — no chrome-service endpoints changed
- [x] Migrations: N/A
- [ ] Dependencies: api-frontend + chrome deploy; swatch-api v2 openapi must return 200 on target env (prod still 401 until swatch-api fix)
- [x] Security: N/A — public API catalog config only

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Cursor

[SWATCH-5049]: https://redhat.atlassian.net/browse/SWATCH-5049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Documentation:
- Expose the rhsm-subscriptions v2 API version in console API documentation configs for beta and stable environments.

## Summary by Sourcery

Documentation:
- List the rhsm-subscriptions v2 API version ahead of v1 in the beta and stable stage console API documentation configs.