### PR TITLE
fix: remove dead V1 workspaces navigation

### DIFF
--- a/static/beta/prod/navigation/iam-navigation.json
+++ b/static/beta/prod/navigation/iam-navigation.json
@@ -97,23 +97,6 @@
           "product": "Identity & Access Management"
         },
         {
-          "id": "workspaces",
-          "appId": "rbac",
-          "title": "Workspaces",
-          "icon": "PlaceholderIcon",
-          "href": "/iam/user-access/workspaces",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["platform.rbac.workspaces-list", true]
-            },
-            {
-              "method": "isOrgAdmin"
-            }
-          ],
-          "product": "Identity & Access Management"
-        },
-        {
           "id": "accessRequests",
           "appId": "rbac",
           "title": "Red Hat Access Requests",

--- a/static/beta/stage/navigation/iam-navigation.json
+++ b/static/beta/stage/navigation/iam-navigation.json
@@ -96,23 +96,6 @@
           "product": "Identity & Access Management"
         },
         {
-          "id": "workspaces",
-          "appId": "rbac",
-          "title": "Workspaces",
-          "icon": "PlaceholderIcon",
-          "href": "/iam/user-access/workspaces",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["platform.rbac.workspaces-list", true]
-            },
-            {
-              "method": "isOrgAdmin"
-            }
-          ],
-          "product": "Identity & Access Management"
-        },
-        {
           "id": "accessRequests",
           "appId": "rbac",
           "title": "Red Hat Access Requests",

--- a/static/stable/prod/navigation/iam-navigation.json
+++ b/static/stable/prod/navigation/iam-navigation.json
@@ -96,23 +96,6 @@
           "product": "Identity & Access Management"
         },
         {
-          "id": "workspaces",
-          "appId": "rbac",
-          "title": "Workspaces",
-          "icon": "PlaceholderIcon",
-          "href": "/iam/user-access/workspaces",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["platform.rbac.workspaces-list", true]
-            },
-            {
-              "method": "isOrgAdmin"
-            }
-          ],
-          "product": "Identity & Access Management"
-        },
-        {
           "id": "accessRequests",
           "appId": "rbac",
           "title": "Red Hat Access Requests",

--- a/static/stable/stage/navigation/iam-navigation.json
+++ b/static/stable/stage/navigation/iam-navigation.json
@@ -98,24 +98,6 @@
           "product": "Identity & Access Management"
         },
         {
-          "id": "workspaces",
-          "appId": "rbac",
-          "title": "Workspaces",
-          "icon": "PlaceholderIcon",
-          "href": "/iam/user-access/workspaces",
-          "permissions": [
-            {
-              "method": "featureFlag",
-              "args": ["platform.rbac.workspaces-list", true]
-            },
-            {
-              "method": "loosePermissions",
-              "args": [["inventory:groups:read"]]
-            }
-          ],
-          "product": "Identity & Access Management"
-        },
-        {
           "id": "accessRequests",
           "appId": "rbac",
           "title": "Red Hat Access Requests",


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->
[RHCLOUD-47873
](https://redhat.atlassian.net/browse/RHCLOUD-47873)

- The `platform.rbac.workspaces-list` feature flag is no longer being used, so the V1 workspaces nav should be removed.
- Fixes issue with workspaces nav showing showing in V1 (where `platform.rbac.workspaces` flag set to false).

---

### How to test locally
<!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
<!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->

---

### Anything reviewers should know?
<!-- Trade-offs, performance considerations, pre/post merge actions required. -->

---

### Checklist
- [ ] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [ ] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Claude Code

## Summary by Sourcery

Remove deprecated V1 workspaces navigation entries from IAM navigation configs.

Bug Fixes:
- Prevent legacy V1 workspaces navigation from appearing when the new workspaces feature flag is disabled.

Enhancements:
- Align IAM navigation configurations across envs to rely solely on the current workspaces feature flag.