### PR TITLE
SWATCH-5049: Expose rhsm-subscriptions v2 in prod API docs config

### DIFF
--- a/static/beta/prod/main.yml
+++ b/static/beta/prod/main.yml
@@ -249,6 +249,7 @@ subscriptions:
   title: Subscriptions
   api:
     versions:
+      - v2
       - v1
     alias:
       - rhsm-subscriptions

--- a/static/stable/prod/main.yml
+++ b/static/stable/prod/main.yml
@@ -303,6 +303,7 @@ subscriptions:
   title: Subscriptions
   api:
     versions:
+      - v2
       - v1
     alias:
       - rhsm-subscriptions


### PR DESCRIPTION
## Summary

- Add `v2` before `v1` under `subscriptions.api.versions` in prod `main.yml` (`static/stable/prod` and `static/beta/prod`).
- Mirrors merged stage PR #1126 so `/docs/api/rhsm-subscriptions/v2` appears in the Hybrid Cloud Console API catalog on prod.

## Prerequisites (merge after)

- [x] `https://console.redhat.com/api/rhsm-subscriptions/v2/openapi.json` returns **200** (swatch-api prod deploy with v2 spec)

## Test plan

- [ ] After deploy, open https://console.redhat.com/docs/api/rhsm-subscriptions/v2 and confirm v2 Swagger loads
- [ ] Overview shows Subscriptions with `v2` and `v1` badges
- [ ] `make validate-schema` (CI)

## Summary by Sourcery

New Features:
- Add rhsm-subscriptions v2 as an exposed API version in the beta and stable production documentation configuration.