### PR TITLE
fix: include FEO-only bundles in bundles-generated.json

### DIFF
--- a/rest/util/createChromeConfiguration.go
+++ b/rest/util/createChromeConfiguration.go
@@ -339,6 +339,24 @@ func parseBundles(bundlesVar string, bundlesOnboardedIdsVar string, env string) 
 		}
 		parsedBundles = append(parsedBundles, mapBundle)
 	}
+
+	for _, generatedBundle := range generatedBundles {
+		generatedMap, ok := generatedBundle.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid generated bundle type")
+		}
+		found := false
+		for _, parsed := range parsedBundles {
+			if parsed["id"] == generatedMap["id"] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			parsedBundles = append(parsedBundles, generatedMap)
+		}
+	}
+
 	bundleData, err := json.MarshalIndent(parsedBundles, "", "  ")
 	return bundleData, err
 }

--- a/rest/util/createChromeConfiguration_test.go
+++ b/rest/util/createChromeConfiguration_test.go
@@ -271,3 +271,114 @@ func TestApiSpecIntegration(t *testing.T) {
 		assert.Equal(t, "insights", bundleLabels[0])
 	})
 }
+
+func TestParseBundles(t *testing.T) {
+	originalWd, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(originalWd)
+
+	setupBundleTestDir := func(t *testing.T, legacyBundles []map[string]interface{}) string {
+		t.Helper()
+		tempDir := t.TempDir()
+		err := os.Chdir(tempDir)
+		assert.NoError(t, err)
+		navDir := filepath.Join(tempDir, "static", "stable", "stage", "navigation")
+		err = os.MkdirAll(navDir, 0755)
+		assert.NoError(t, err)
+		for _, bundle := range legacyBundles {
+			id := bundle["id"].(string)
+			data, err := json.Marshal(bundle)
+			assert.NoError(t, err)
+			err = os.WriteFile(filepath.Join(navDir, id+"-navigation.json"), data, 0644)
+			assert.NoError(t, err)
+		}
+		return tempDir
+	}
+
+	t.Run("FEO-only bundle is included in output", func(t *testing.T) {
+		legacyBundle := map[string]interface{}{
+			"id":       "insights",
+			"title":    "Insights",
+			"navItems": []interface{}{},
+		}
+		setupBundleTestDir(t, []map[string]interface{}{legacyBundle})
+		defer os.Chdir(originalWd)
+
+		feoBundle := `[{"id":"pcm","title":"PCM","navItems":[{"id":"pcm-home","title":"Home"}]}]`
+		result, err := parseBundles(feoBundle, "", "stage")
+		assert.NoError(t, err)
+
+		var parsed []map[string]interface{}
+		err = json.Unmarshal(result, &parsed)
+		assert.NoError(t, err)
+
+		assert.Len(t, parsed, 2, "Expected legacy bundle + FEO-only bundle")
+
+		ids := make([]string, len(parsed))
+		for i, b := range parsed {
+			ids[i] = b["id"].(string)
+		}
+		assert.Contains(t, ids, "insights")
+		assert.Contains(t, ids, "pcm")
+	})
+
+	t.Run("FEO bundle matching legacy ID is not duplicated", func(t *testing.T) {
+		legacyBundle := map[string]interface{}{
+			"id":       "insights",
+			"title":    "Insights",
+			"navItems": []interface{}{},
+		}
+		setupBundleTestDir(t, []map[string]interface{}{legacyBundle})
+		defer os.Chdir(originalWd)
+
+		feoBundle := `[{"id":"insights","title":"Insights FEO","navItems":[]}]`
+		result, err := parseBundles(feoBundle, "", "stage")
+		assert.NoError(t, err)
+
+		var parsed []map[string]interface{}
+		err = json.Unmarshal(result, &parsed)
+		assert.NoError(t, err)
+
+		assert.Len(t, parsed, 1, "Matching FEO bundle should not create a duplicate")
+	})
+
+	t.Run("Multiple FEO-only bundles are all included", func(t *testing.T) {
+		legacyBundle := map[string]interface{}{
+			"id":       "insights",
+			"title":    "Insights",
+			"navItems": []interface{}{},
+		}
+		setupBundleTestDir(t, []map[string]interface{}{legacyBundle})
+		defer os.Chdir(originalWd)
+
+		feoBundle := `[{"id":"pcm","title":"PCM","navItems":[]},{"id":"foo","title":"Foo","navItems":[]}]`
+		result, err := parseBundles(feoBundle, "", "stage")
+		assert.NoError(t, err)
+
+		var parsed []map[string]interface{}
+		err = json.Unmarshal(result, &parsed)
+		assert.NoError(t, err)
+
+		assert.Len(t, parsed, 3, "Expected legacy + 2 FEO-only bundles")
+	})
+
+	t.Run("Empty FEO_BUNDLES returns only legacy bundles", func(t *testing.T) {
+		legacyBundle := map[string]interface{}{
+			"id":       "insights",
+			"title":    "Insights",
+			"navItems": []interface{}{},
+		}
+		setupBundleTestDir(t, []map[string]interface{}{legacyBundle})
+		defer os.Chdir(originalWd)
+
+		result, err := parseBundles("", "", "stage")
+		assert.NoError(t, err)
+
+		var parsed []map[string]interface{}
+		err = json.Unmarshal(result, &parsed)
+		assert.NoError(t, err)
+
+		assert.Len(t, parsed, 1)
+		assert.Equal(t, "insights", parsed[0]["id"])
+	})
+}


### PR DESCRIPTION
## Summary
- `parseBundles` only iterated over legacy navigation files and matched FEO_BUNDLES entries against them. Bundles that existed only in FEO_BUNDLES (like PCM) with no legacy navigation file counterpart were silently dropped from the output.
- After the legacy merge loop, append any generated bundles whose IDs were not already processed.
- Added tests for `parseBundles` covering FEO-only bundles, deduplication, multiple FEO bundles, and empty FEO_BUNDLES.

## Test plan
- [x] `go test -v -run TestParseBundles ./rest/util/` — all 4 subtests pass
- [x] `go test ./rest/util/` — full package passes
- [x] Set `FEO_BUNDLES` with a bundle ID that has no legacy nav file (e.g. PCM), run `make dev`, verify it appears in `bundles-generated.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure generated navigation bundles include both legacy and FEO-only entries without duplication.

Bug Fixes:
- Include FEO-only bundles that lack legacy navigation files in the generated bundles output while avoiding duplicate entries for matching IDs.

Tests:
- Add unit tests for parseBundles covering FEO-only bundles, deduplication of overlapping bundles, handling multiple FEO-only bundles, and behavior when FEO_BUNDLES is empty.