### PR TITLE
chore: setting all nav bundles as onboarded to FEO RHCLOUD-47849

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -304,7 +304,7 @@ parameters:
   value: '10'
 - description: Bundles navigation fully onboarded to FEO
   name: FEO_BUNDLES_ONBOARDED_IDS
-  value: '["user-preferences"]'
+  value: '["ansible", "docs", "iam", "openshift", "iam", "internal", "insights", "application-services", "mosaic", "openshift", "quay", "settings", "staging", "subscriptions", "user-preferences"]'
 - description: Enable or disable clowder
   name: CLOWDER_ENABLED
   value: 'true'


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->
setting all nav bundles as onboarded to FEO
Jira: RHCLOUD-47849

---

### How to test locally
<!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
<!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->

---

### Anything reviewers should know?
<!-- Trade-offs, performance considerations, pre/post merge actions required. -->

---

### Checklist
- [ ] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [ ] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->

## Summary by Sourcery

Enhancements:
- Expand the FEO_BUNDLES_ONBOARDED_IDS parameter to include all navigation bundle identifiers in clowdapp deployment config.